### PR TITLE
release: 1.2.1 — AUTO binding by default, mocks wired out of the box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,17 +18,20 @@ before it can reach a release. (There was briefly a separate `sdk:plugin-api` mo
 third-party plugin framework; it was removed before ever shipping — see Removed, below — so it never
 joined this list.)
 
-## Unreleased
+## 1.2.1 — 2026-08-17
 
 Three default changes, aimed at the same complaint: a fresh integration showed a `127.0.0.1` URL
 that needed `adb forward` before it displayed anything, and a Mocks screen that could not add a
 mock. See [docs/MIGRATION.md](docs/MIGRATION.md#upgrading-from-120) for the upgrade path.
 
-**Version note, deliberately unresolved here:** under this file's own
-[policy](#versioning-and-stability-policy), adding a constant to a public enum is source-breaking
-for any host that `when`s exhaustively over `BindingMode`/`BrowserBinding`, and flipping a security
-default is a behavioural break. That reads as a major, not a minor. The number is left for the
-release decision rather than assumed.
+**Version note:** shipped as a patch, and that number is generous to itself. Under this file's own
+[policy](#versioning-and-stability-policy) this reads as a major — adding a constant to a public
+enum is source-breaking for any host that `when`s exhaustively over `BindingMode`/`BrowserBinding`,
+and flipping a security default is a behavioural break. Nothing was removed and no signature
+changed, so a host that does neither of those things upgrades without touching anything; the two
+cases that do not are spelled out in
+[docs/MIGRATION.md](docs/MIGRATION.md#upgrading-from-120). Read it before treating the version
+number as permission to skip the diff.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ links no server code, and the Gradle plugin fails the build if the real runtime 
 ```kotlin
 plugins {
     id("com.android.application")
-    id("io.github.devconsole-android") version "1.2.0"
+    id("io.github.devconsole-android") version "1.2.1"
 }
 
 dependencies {
-    debugImplementation("io.github.devconsole-android:devconsole:1.2.0")
-    releaseImplementation("io.github.devconsole-android:devconsole-noop:1.2.0")
+    debugImplementation("io.github.devconsole-android:devconsole:1.2.1")
+    releaseImplementation("io.github.devconsole-android:devconsole-noop:1.2.1")
 }
 ```
 
@@ -314,8 +314,8 @@ Add the adapter — it is not part of the `devconsole` umbrella, so that Firebas
 classpath of an app that doesn't use it:
 
 ```kotlin
-debugImplementation("io.github.devconsole-android:devconsole-remote-config-firebase:1.2.0")
-releaseImplementation("io.github.devconsole-android:devconsole-remote-config-firebase-noop:1.2.0")
+debugImplementation("io.github.devconsole-android:devconsole-remote-config-firebase:1.2.1")
+releaseImplementation("io.github.devconsole-android:devconsole-remote-config-firebase-noop:1.2.1")
 ```
 
 > These two artifacts first ship in `1.2.0`; earlier versions do not have them.
@@ -406,8 +406,8 @@ dependencyResolutionManagement {
 ```kotlin
 dependencies {
     // Group is com.github.devconsole-android.DevConsole; artifact ids match the tables above.
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.0")
-    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.0")
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.1")
+    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.1")
 }
 ```
 

--- a/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
+++ b/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
@@ -84,7 +84,7 @@ class PublishingConventionPlugin : Plugin<Project> {
 
     private companion object {
         const val MAVEN_GROUP = "io.github.devconsole-android"
-        const val SDK_VERSION = "1.2.0"
+        const val SDK_VERSION = "1.2.1"
         const val PROJECT_URL = "https://github.com/devconsole-android/DevConsole"
     }
 }

--- a/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
+++ b/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
@@ -37,7 +37,7 @@ devConsole {
     protectedDependencyPaths.set(setOf(":sdk:full"))        // default; override for a differently-pathed module
     failBuildOnUnsafeVariant.set(true)                      // default; false downgrades to a warning
     autoWireDependencies.set(true)                          // default; false to declare coordinates yourself
-    sdkVersion.set("1.2.0")                                 // default; the plugin's own version
+    sdkVersion.set("1.2.1")                                 // default; the plugin's own version
 }
 ```
 

--- a/docs/MAVEN_PUBLISHING.md
+++ b/docs/MAVEN_PUBLISHING.md
@@ -48,7 +48,7 @@ your local `~/.gradle/gradle.properties`.
 Central's release path does **not** accept `-SNAPSHOT` versions. Before the first real publish,
 change `SDK_VERSION` in
 `build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt`
-(and `version` in `gradle-plugin/build.gradle.kts`) to a real version, e.g. `1.2.0`.
+(and `version` in `gradle-plugin/build.gradle.kts`) to a real version, e.g. `1.2.1`.
 
 **Locally:**
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -69,5 +69,5 @@ than once during active development — most recently a facade reshape (`start()
 `startBrowser()`/`startBrowserAsync()`, returning `StartResult.Started(endpoint, access)`), the
 removal of `BindingMode.AUTO`/NSD/auto-start, the replacement of pairing/role-based access with the
 single SESSION_CODE flow, and the removal of the generic plugin framework. If you're carrying code
-against an earlier snapshot of this repository, check the **Unreleased** section of
+against an earlier snapshot of this repository, check the pre-1.0 entries in
 [CHANGELOG.md](../CHANGELOG.md) for the full list before updating.

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 // Must share a top-level namespace with the plugin ID (a Plugin Portal requirement) and match
 // the SDK's Maven group.
 group = "io.github.devconsole-android"
-version = "1.2.0"
+version = "1.2.1"
 
 // Targets Java 17: this plugin JAR runs inside the Gradle daemon (AGP 8.13.0
 // requires JDK 17) and compiles against com.android.tools.build:gradle:8.13.0,

--- a/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
@@ -397,7 +397,7 @@ abstract class VerifyDevConsolePackagedArtifactTask : DefaultTask() {
     }
 }
 
-private const val DEFAULT_SDK_VERSION = "1.2.0"
+private const val DEFAULT_SDK_VERSION = "1.2.1"
 private const val DEVCONSOLE_GROUP = "io.github.devconsole-android"
 
 /**

--- a/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
@@ -837,12 +837,12 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
         )
 
         // release is PROTECTED by default, so auto-wire adds the noop core coordinate. The published
-        // coordinate is 1.2.0 -- the DEFAULT_SDK_VERSION must not point at a 1.2.0-SNAPSHOT that was
+        // coordinate is 1.2.1 -- the DEFAULT_SDK_VERSION must not point at a 1.2.1-SNAPSHOT that was
         // never published, which would make every zero-config release build fail to resolve.
         val result = runner("dependencies", "--configuration", "releaseImplementation").build()
 
-        assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole-noop:1.2.0"))
-        assertTrue(result.output, !result.output.contains("1.2.0-SNAPSHOT"))
+        assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole-noop:1.2.1"))
+        assertTrue(result.output, !result.output.contains("1.2.1-SNAPSHOT"))
     }
 
     @Test
@@ -878,7 +878,7 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
             extraBuildScript =
                 """
                 dependencies {
-                    add("debugImplementation", "io.github.devconsole-android:devconsole-ui-compose:1.2.0")
+                    add("debugImplementation", "io.github.devconsole-android:devconsole-ui-compose:1.2.1")
                 }
                 """.trimIndent(),
         )
@@ -887,7 +887,7 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
         // debug is ENABLED, so the core runtime ("devconsole") must still be auto-wired alongside the
         // host's add-on declaration -- the add-on alone does not count as declaring the core runtime.
-        assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole:1.2.0"))
+        assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole:1.2.1"))
         assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole-ui-compose"))
     }
 }

--- a/samples/compose-app/build.gradle.kts
+++ b/samples/compose-app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.compose"
         versionCode = 1
-        versionName = "1.2.0-SNAPSHOT"
+        versionName = "1.2.1-SNAPSHOT"
     }
 }
 

--- a/samples/foundation-app/build.gradle.kts
+++ b/samples/foundation-app/build.gradle.kts
@@ -31,6 +31,6 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample"
         versionCode = 1
-        versionName = "1.2.0-SNAPSHOT"
+        versionName = "1.2.1-SNAPSHOT"
     }
 }

--- a/samples/views-java-app/build.gradle.kts
+++ b/samples/views-java-app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.viewsjava"
         versionCode = 1
-        versionName = "1.2.0-SNAPSHOT"
+        versionName = "1.2.1-SNAPSHOT"
     }
 }
 


### PR DESCRIPTION
## What

Numbers the changes that landed in #13 as **1.2.1** and closes the `Unreleased` section.

The patch number is a deliberate call, not what [CHANGELOG.md's own policy](../blob/main/CHANGELOG.md#versioning-and-stability-policy) computes. `BindingMode.AUTO` / `BrowserBinding.AUTO` are new constants on public enums, which breaks any host that `when`s over them exhaustively, and the default binding moving off loopback is a behavioural change to a security default — both read as major. Nothing was removed and no signature changed, so the upgrade is a no-op for hosts doing neither. Rather than let the version number imply more compatibility than there is, the changelog's version note and `docs/MIGRATION.md` state the two breaking cases outright.

Version sites bumped, matching the shape of the 1.2.0 and 1.1.1 release commits:

- `SDK_VERSION` in `PublishingConventionPlugin.kt`
- `version` and `DEFAULT_SDK_VERSION` in the Gradle plugin
- the plugin functional-test coordinates
- README install snippets (Maven Central and JitPack), plus the Remote Config adapter snippet
- `docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md`, `docs/MAVEN_PUBLISHING.md`
- the three samples' `versionName`

One extra line: `docs/MIGRATION.md` pointed readers at the **Unreleased** heading this commit consumes, so it now points at the pre-1.0 entries instead.

Historical `1.2.0` references (the "these artifacts first ship in 1.2.0" note, `## Upgrading from 1.2.0`, "to keep 1.2.0 behaviour") are left alone — they name a specific past release, not the current one.

## Verification

Run locally with `ANDROID_HOME` set:

- [x] `./gradlew testDebugUnitTest` — passing
- [x] `./gradlew ktlintCheck detekt` — clean, no new findings
- [x] `./gradlew apiCheck` — clean; no API changed in this diff
- [x] `./gradlew :gradle-plugin:test` — 29/29 passing, including `auto-wired coordinate resolves to the released non-snapshot version`, which is the test that pins `DEFAULT_SDK_VERSION` to a real published coordinate

No protected-variant boundary moved, so no sample assemble/verify run was needed for this diff.

## Checklist

- [x] Capture-path code (network/socket/push) never throws into the host app — untouched
- [x] No new sensitive data is captured, logged, or exported — untouched
- [x] Docs updated (README, both version-bearing docs, CHANGELOG, MIGRATION)
- [x] Scoped to one logical change

## Anything reviewers should look at closely

**The version number itself.** `1.2.1` was chosen deliberately over the `2.0.0` the changelog argued for; if you disagree, this is the commit to say so on — after the tag and the Central publish it is much more expensive to revisit.

Security-adjacent, stated plainly: this release ships a loosened default. The server now binds a real network interface out of the box and the dashboard speaks plaintext HTTP, so on an untrusted network headers, tokens, and bodies are readable by anyone on it. That change landed in #13; this PR only puts a number on it.

`DEFAULT_SDK_VERSION` now names `1.2.1`, which is not on Maven Central until this release publishes — the same ordering the 1.2.0 and 1.1.1 release commits used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)