### PR TITLE
Update version to 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ before it can reach a release. (There was briefly a separate `sdk:plugin-api` mo
 third-party plugin framework; it was removed before ever shipping — see Removed, below — so it never
 joined this list.)
 
+## 1.2.3 — 2026-08-18
+
+### Changed
+
+- **JitPack coordinates are spelled without the `v` prefix.** JitPack looks a requested version up
+  as a git tag and falls back to the `v`-prefixed spelling when no bare tag exists, so
+  `com.github.devconsole-android.DevConsole:devconsole:1.2.3` serves the `v1.2.3` build exactly as
+  `v1.2.3` does. The docs and the Gradle plugin's `sdkVersion` default now use the bare form, which
+  reads the same as the version the plugin carries on the Gradle Plugin Portal. Nothing breaks:
+  `v`-prefixed coordinates keep resolving, and an existing 1.2.2 host needs no change. This
+  supersedes the note under 1.2.2 below, which said the bare version does not resolve — that was
+  generalised from `1.2.1`, whose bare build failed on JitPack for unrelated reasons and stays
+  cached as a failure, so 1.2.1 alone must be named `v1.2.1`.
+
 ## 1.2.2 — 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ dependencyResolutionManagement {
 ```kotlin
 plugins {
     id("com.android.application")
-    id("io.github.devconsole-android") version "1.2.2"
+    id("io.github.devconsole-android") version "1.2.3"
 }
 
 dependencies {
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:v1.2.2")
-    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:v1.2.2")
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.3")
+    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.3")
 }
 ```
 
@@ -353,8 +353,8 @@ Add the adapter — it is not part of the `devconsole` umbrella, so that Firebas
 classpath of an app that doesn't use it:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:v1.2.2")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:v1.2.2")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:1.2.3")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:1.2.3")
 ```
 
 > These two artifacts first ship in `1.2.0`; earlier versions do not have them.
@@ -429,12 +429,12 @@ You never name those. Every module publishes sources, javadoc, and a POM.
 ### Versions and unreleased code
 
 All 34 library artifacts come from [JitPack](https://jitpack.io/#devconsole-android/DevConsole),
-which builds a ref on demand — so **the version is a git ref, spelled exactly as the ref is**.
-Releases are tagged `v*`, which is why the coordinates above read `v1.2.2` and not `1.2.2`; the
-bare form is a different ref and does not resolve. Any branch works as `<branch>-SNAPSHOT`, with
-`/` written as `~`, so a `feature/x` branch is `feature~x-SNAPSHOT` — that is how you try an
-unreleased fix before it ships. JitPack support starts at **v1.1.1**; earlier tags do not build
-there. Two things to know:
+which builds a ref on demand. Releases are tagged `v1.2.3`, and JitPack resolves a bare version
+against the `v`-prefixed tag, which is why the coordinates above read `1.2.3` — the same spelling
+the Gradle plugin uses on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
+`~`, so a `feature/x` branch is `feature~x-SNAPSHOT` — that is how you try an unreleased fix before
+it ships. JitPack support starts at **1.1.1**; earlier tags do not build there. Two things to
+know:
 
 - **The Gradle plugin comes from the Gradle Plugin Portal, not JitPack**, because the `plugins { }`
   DSL cannot resolve a plugin marker from JitPack. That is why the quick start adds JitPack for

--- a/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
+++ b/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
@@ -74,7 +74,7 @@ class PublishingConventionPlugin : Plugin<Project> {
         // The POM group. JitPack rewrites it to com.github.devconsole-android.DevConsole when it
         // serves a build, so consumers name that group, not this one.
         const val MAVEN_GROUP = "io.github.devconsole-android"
-        const val SDK_VERSION = "1.2.2"
+        const val SDK_VERSION = "1.2.3"
         const val PROJECT_URL = "https://github.com/devconsole-android/DevConsole"
     }
 }

--- a/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
+++ b/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
@@ -37,7 +37,7 @@ devConsole {
     protectedDependencyPaths.set(setOf(":sdk:full"))        // default; override for a differently-pathed module
     failBuildOnUnsafeVariant.set(true)                      // default; false downgrades to a warning
     autoWireDependencies.set(true)                          // default; false to declare coordinates yourself
-    sdkVersion.set("v1.2.2")                                // default; the JitPack tag to resolve
+    sdkVersion.set("1.2.3")                                 // default; the JitPack version to resolve
 }
 ```
 

--- a/docs/GETTING_STARTED_COMPOSE.md
+++ b/docs/GETTING_STARTED_COMPOSE.md
@@ -24,9 +24,9 @@ plugins {
 }
 
 dependencies {
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:v<version>")
-    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:v<version>")
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole-ui-compose:v<version>") // optional, only for the launcher panel
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:<version>")
+    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:<version>")
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole-ui-compose:<version>") // optional, only for the launcher panel
 }
 
 devConsole {
@@ -35,9 +35,9 @@ devConsole {
 }
 ```
 
-`v<version>` is a JitPack version, which is the git tag verbatim — releases are tagged `v*`, so
-`v1.2.2`, not `1.2.2`. The plugin is the exception: it comes from the Gradle Plugin Portal, where
-its version is bare.
+`<version>` is a JitPack version — `1.2.3` for the current release. Releases are tagged `v1.2.3`,
+and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
+form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 
 There is no BOM. `devconsole` (the debug runtime) and `devconsole-noop` are the only two coordinates
 a normal integration names; everything else is `devconsole-<module>`.

--- a/docs/GETTING_STARTED_XML_KOTLIN.md
+++ b/docs/GETTING_STARTED_XML_KOTLIN.md
@@ -24,9 +24,9 @@ plugins {
 }
 
 dependencies {
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:v<version>")
-    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:v<version>")
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole-ui-views:v<version>") // optional, only for the launcher panel
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:<version>")
+    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:<version>")
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole-ui-views:<version>") // optional, only for the launcher panel
 }
 
 devConsole {
@@ -35,9 +35,9 @@ devConsole {
 }
 ```
 
-`v<version>` is a JitPack version, which is the git tag verbatim — releases are tagged `v*`, so
-`v1.2.2`, not `1.2.2`. The plugin is the exception: it comes from the Gradle Plugin Portal, where
-its version is bare.
+`<version>` is a JitPack version — `1.2.3` for the current release. Releases are tagged `v1.2.3`,
+and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
+form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 
 There is no BOM. `devconsole` (the debug runtime) and `devconsole-noop` are the only two coordinates
 a normal integration names; everything else is `devconsole-<module>`.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -26,12 +26,13 @@ dependencyResolutionManagement {
 ```
 
 2. Change the group on every DevConsole dependency from `io.github.devconsole-android` to
-   `com.github.devconsole-android.DevConsole`, and prefix the version with `v` — JitPack serves a
-   build under its git ref name, and releases are tagged `v*`. Artifact IDs are unchanged:
+   `com.github.devconsole-android.DevConsole`. Artifact IDs and the version spelling are unchanged —
+   JitPack serves a build under its git ref name, and resolves a bare version against the matching
+   `v*` release tag:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole:v1.2.2")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:v1.2.2")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.3")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.3")
 ```
 
 If you rely on the plugin's `autoWireDependencies` (the default), step 2 is done for you — you only

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -90,17 +90,18 @@ plugins {
     id("io.github.devconsole-android") version "<version>"
 }
 dependencies {
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:v<version>")
-    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:v<version>")
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:<version>")
+    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:<version>")
 }
 ```
 
-`<version>` is the git ref verbatim, so for a release it is the **`v`-prefixed tag** (`v1.2.2`) —
-JitPack does not strip the prefix, and the bare form 404s. Any branch works as
-`<branch>-SNAPSHOT`, with `/` written as `~`, so a `feature/x` branch is `feature~x-SNAPSHOT`.
-Note the Gradle plugin is the exception: it comes from the Portal, where its version is the bare
-`1.2.2`. JitPack support starts at **v1.1.1**; earlier
-tags do not build there.
+`<version>` is a git ref. JitPack looks it up as a tag and falls back to the `v`-prefixed spelling
+when no bare tag exists, so a release resolves either way — `1.2.3` and `v1.2.3` both serve the
+`v1.2.3` build. Prefer the bare form: it is what the docs show, and it matches the version the
+Gradle plugin carries on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
+`~`, so a `feature/x` branch is `feature~x-SNAPSHOT`. JitPack support starts at **1.1.1**; earlier
+tags do not build there, and bare `1.2.1` is a cached failed build — that one release resolves only
+as `v1.2.1`.
 
 See [BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md](BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md) for what the
 plugin enforces about the debug/release split.

--- a/docs/REMOTE_CONFIG.md
+++ b/docs/REMOTE_CONFIG.md
@@ -25,13 +25,13 @@ Cloud Messaging. Add the adapter coordinate yourself; it is deliberately not re-
 `devconsole` umbrella.
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:v<version>")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:v<version>")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:<version>")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:<version>")
 ```
 
-`v<version>` is a JitPack version, which is the git tag verbatim — releases are tagged `v*`, so
-`v1.2.2`, not `1.2.2`. The plugin is the exception: it comes from the Gradle Plugin Portal, where
-its version is bare.
+`<version>` is a JitPack version — `1.2.3` for the current release. Releases are tagged `v1.2.3`,
+and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
+form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 
 A provider constructed later — through DI, or after a first fetch completes — can register itself:
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 // Must share a top-level namespace with the plugin ID (a Plugin Portal requirement) and match
 // the SDK's Maven group.
 group = "io.github.devconsole-android"
-version = "1.2.2"
+version = "1.2.3"
 
 // Targets Java 17: this plugin JAR runs inside the Gradle daemon (AGP 8.13.0
 // requires JDK 17) and compiles against com.android.tools.build:gradle:8.13.0,

--- a/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
@@ -397,9 +397,11 @@ abstract class VerifyDevConsolePackagedArtifactTask : DefaultTask() {
     }
 }
 
-// JitPack serves a build under its git ref name, and this repo tags `v*` -- a bare "1.2.2"
-// does not resolve. Keep the `v`.
-private const val DEFAULT_SDK_VERSION = "v1.2.2"
+// JitPack serves a build under its git ref name. This repo tags `v*`, and JitPack resolves a
+// requested version against the `v`-prefixed tag when no bare tag exists, so "1.2.3" reaches the
+// v1.2.3 build -- and reads the same as the version this plugin carries on the Plugin Portal.
+// Bump in step with SDK_VERSION in convention-publishing; the tag must exist before this resolves.
+private const val DEFAULT_SDK_VERSION = "1.2.3"
 
 /** JitPack's group for this repo — what auto-wiring declares. */
 private const val DEVCONSOLE_GROUP = "com.github.devconsole-android.DevConsole"

--- a/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
@@ -870,12 +870,12 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
         )
 
         // release is PROTECTED by default, so auto-wire adds the noop core coordinate. The published
-        // coordinate is 1.2.2 -- the DEFAULT_SDK_VERSION must not point at a 1.2.2-SNAPSHOT that was
+        // coordinate is 1.2.3 -- the DEFAULT_SDK_VERSION must not point at a 1.2.3-SNAPSHOT that was
         // never published, which would make every zero-config release build fail to resolve.
         val result = runner("dependencies", "--configuration", "releaseImplementation").build()
 
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:v1.2.2"))
-        assertTrue(result.output, !result.output.contains("1.2.2-SNAPSHOT"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.3"))
+        assertTrue(result.output, !result.output.contains("1.2.3-SNAPSHOT"))
     }
 
     @Test
@@ -925,13 +925,13 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
     @Test
     fun `the JitPack coordinate trips the declared-dependency check`() {
-        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "v1.2.2")
+        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "1.2.3")
         writeFixture(
             devConsoleBlock = "autoWireDependencies.set(false)",
             extraBuildScript =
                 """
                 dependencies {
-                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:v1.2.2")
+                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:1.2.3")
                 }
                 """.trimIndent(),
         )
@@ -971,7 +971,7 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
         // debug is ENABLED, so the core runtime ("devconsole") must still be auto-wired alongside the
         // host's add-on declaration -- the add-on alone does not count as declaring the core runtime.
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:v1.2.2"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.2.3"))
         assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole-ui-compose"))
     }
 

--- a/samples/compose-app/build.gradle.kts
+++ b/samples/compose-app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.compose"
         versionCode = 1
-        versionName = "1.2.2-SNAPSHOT"
+        versionName = "1.2.3-SNAPSHOT"
     }
 }
 

--- a/samples/foundation-app/build.gradle.kts
+++ b/samples/foundation-app/build.gradle.kts
@@ -31,6 +31,6 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample"
         versionCode = 1
-        versionName = "1.2.2-SNAPSHOT"
+        versionName = "1.2.3-SNAPSHOT"
     }
 }

--- a/samples/views-java-app/build.gradle.kts
+++ b/samples/views-java-app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.viewsjava"
         versionCode = 1
-        versionName = "1.2.2-SNAPSHOT"
+        versionName = "1.2.3-SNAPSHOT"
     }
 }
 

--- a/sdk/storage-room/README.md
+++ b/sdk/storage-room/README.md
@@ -6,12 +6,12 @@
 
 1. Add dependency to your build file:
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole-storage-room:v<version>")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole-storage-room:<version>")
 ```
 
-`v<version>` is a JitPack version, which is the git tag verbatim — releases are tagged `v*`, so
-`v1.2.2`, not `1.2.2`. The plugin is the exception: it comes from the Gradle Plugin Portal, where
-its version is bare.
+`<version>` is a JitPack version — `1.2.3` for the current release. Releases are tagged `v1.2.3`,
+and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
+form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 
 `sdk:full` wires this module in automatically for durable timeline storage — no additional
 registration is required. Scope it to `debugImplementation` (never plain `implementation`) yourself


### PR DESCRIPTION
## What

One or two sentences on what changed and why (the "why" matters more than the "what" — the diff
already shows the what).

## Verification

Which `./gradlew` commands did you run, and what did they confirm? (See
[CONTRIBUTING.md](../CONTRIBUTING.md#building-and-testing) for the standard set.)

- [ ] `./gradlew testDebugUnitTest` — passing
- [ ] `./gradlew ktlintCheck detekt` — clean (or new detekt findings are justified, not baselined away)
- [ ] `./gradlew apiCheck` — clean, or `apiDump` is included in this diff because the public API changed
- [ ] If this touches a debug/release or protected-variant boundary: sample assemble/verify commands
      run for the affected sample(s) (`:samples:<name>:assembleRelease
      :samples:<name>:verifyDevConsoleProtectedArtifacts`)

## Checklist

- [ ] Capture-path code (network/socket/push) never throws into the host app
- [ ] No new sensitive data is captured, logged, or exported without going through
      `RedactionEngine` first
- [ ] Docs updated if behavior, an API, or a config field changed
      (see [docs/README.md](../docs/README.md) for the index)
- [ ] This PR is scoped to one logical change

## Anything reviewers should look at closely

Optional — call out anything you're unsure about, a tradeoff you made, or a spot you want a second
look at.
