### PR TITLE
fix: name the SDK's FileProvider so it stops colliding with the host's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ before it can reach a release. (There was briefly a separate `sdk:plugin-api` mo
 third-party plugin framework; it was removed before ever shipping — see Removed, below — so it never
 joined this list.)
 
+## 1.2.4 — 2026-08-20
+
+### Fixed
+
+- **The SDK's `FileProvider` no longer collides with the host's, which broke integration outright.**
+  `sdk:full` declared its Share-sheet provider as `androidx.core.content.FileProvider`, and the
+  manifest merger keys `<provider>` nodes by `android:name` rather than by authority — so in any app
+  that already declares a FileProvider of its own (camera capture, image picking, an attachment
+  picker), the two collapsed into one node and the host's debug build failed on the differing
+  `android:authorities` and `android.support.FILE_PROVIDER_PATHS` resource. The provider is now
+  `io.devconsole.DevConsoleFileProvider`, a name no host would pick, and it reaches its paths through
+  `FileProvider`'s resource-id constructor so the declaration carries no meta-data child to collide
+  over either. The authority is unchanged (`<applicationId>.devconsole.files`), so nothing in a host
+  app moves and no host that already built keeps working differently. Anyone still on 1.2.3 should
+  not apply the `tools:replace="android:authorities"` the merger suggests — it settles the conflict
+  by dropping the SDK's authority, and the Files screen's Share action then throws the first time it
+  is used; [docs/FAQ_TROUBLESHOOTING.md](docs/FAQ_TROUBLESHOOTING.md) has the one-line workaround
+  that keeps both providers. `samples:compose-app` now declares a FileProvider of its own for no
+  reason other than to reproduce a host of that shape, so CI fails on a reintroduction instead of a
+  consumer's build doing it.
+
 ## 1.2.3 — 2026-08-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ dependencyResolutionManagement {
 ```kotlin
 plugins {
     id("com.android.application")
-    id("io.github.devconsole-android") version "1.2.3"
+    id("io.github.devconsole-android") version "1.2.4"
 }
 
 dependencies {
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.3")
-    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.3")
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.4")
+    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.4")
 }
 ```
 
@@ -353,8 +353,8 @@ Add the adapter — it is not part of the `devconsole` umbrella, so that Firebas
 classpath of an app that doesn't use it:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:1.2.3")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:1.2.3")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:1.2.4")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:1.2.4")
 ```
 
 > These two artifacts first ship in `1.2.0`; earlier versions do not have them.
@@ -429,8 +429,8 @@ You never name those. Every module publishes sources, javadoc, and a POM.
 ### Versions and unreleased code
 
 All 34 library artifacts come from [JitPack](https://jitpack.io/#devconsole-android/DevConsole),
-which builds a ref on demand. Releases are tagged `v1.2.3`, and JitPack resolves a bare version
-against the `v`-prefixed tag, which is why the coordinates above read `1.2.3` — the same spelling
+which builds a ref on demand. Releases are tagged `v1.2.4`, and JitPack resolves a bare version
+against the `v`-prefixed tag, which is why the coordinates above read `1.2.4` — the same spelling
 the Gradle plugin uses on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
 `~`, so a `feature/x` branch is `feature~x-SNAPSHOT` — that is how you try an unreleased fix before
 it ships. JitPack support starts at **1.1.1**; earlier tags do not build there. Two things to

--- a/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
+++ b/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
@@ -74,7 +74,7 @@ class PublishingConventionPlugin : Plugin<Project> {
         // The POM group. JitPack rewrites it to com.github.devconsole-android.DevConsole when it
         // serves a build, so consumers name that group, not this one.
         const val MAVEN_GROUP = "io.github.devconsole-android"
-        const val SDK_VERSION = "1.2.3"
+        const val SDK_VERSION = "1.2.4"
         const val PROJECT_URL = "https://github.com/devconsole-android/DevConsole"
     }
 }

--- a/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
+++ b/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
@@ -37,7 +37,7 @@ devConsole {
     protectedDependencyPaths.set(setOf(":sdk:full"))        // default; override for a differently-pathed module
     failBuildOnUnsafeVariant.set(true)                      // default; false downgrades to a warning
     autoWireDependencies.set(true)                          // default; false to declare coordinates yourself
-    sdkVersion.set("1.2.3")                                 // default; the JitPack version to resolve
+    sdkVersion.set("1.2.4")                                 // default; the JitPack version to resolve
 }
 ```
 

--- a/docs/FAQ_TROUBLESHOOTING.md
+++ b/docs/FAQ_TROUBLESHOOTING.md
@@ -54,6 +54,18 @@ only one is live at a time, and each lasts five minutes. There's no approval ste
 no automatic regeneration, so issue a fresh code from the More screen for each new browser. See
 [LAN_PERMISSION_AND_TROUBLESHOOTING.md](LAN_PERMISSION_AND_TROUBLESHOOTING.md#session-codes-session_code_expired--session_code_invalid).
 
+**My debug build fails with a manifest merger conflict on `androidx.core.content.FileProvider`.**
+Upgrade to 1.2.4, where the SDK declares its provider as `io.devconsole.DevConsoleFileProvider`
+instead. The merger keys `<provider>` nodes by `android:name` rather than by authority, so through
+1.2.3 the SDK's provider and the one your app already declares — for camera capture, image picking,
+or any share sheet — were the same node, and the merge failed on the differing `android:authorities`
+and paths resource. Do not apply the `tools:replace="android:authorities"` the merger suggests: it
+resolves the conflict by dropping `<applicationId>.devconsole.files`, so the Files screen's Share
+action throws the first time someone taps it. If you cannot upgrade yet, give *your* provider a
+unique class name instead — `class AppFileProvider : FileProvider()`, with `android:name` pointing
+at it — which keeps your authority, your paths file, and every `getUriForFile` call exactly as they
+are.
+
 **Where do I report a security issue?** Privately, never in a public issue.
 [SECURITY.md](../SECURITY.md) has the details.
 

--- a/docs/GETTING_STARTED_COMPOSE.md
+++ b/docs/GETTING_STARTED_COMPOSE.md
@@ -35,7 +35,7 @@ devConsole {
 }
 ```
 
-`<version>` is a JitPack version — `1.2.3` for the current release. Releases are tagged `v1.2.3`,
+`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/docs/GETTING_STARTED_XML_KOTLIN.md
+++ b/docs/GETTING_STARTED_XML_KOTLIN.md
@@ -35,7 +35,7 @@ devConsole {
 }
 ```
 
-`<version>` is a JitPack version — `1.2.3` for the current release. Releases are tagged `v1.2.3`,
+`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
    `v*` release tag:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.3")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.3")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.4")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.4")
 ```
 
 If you rely on the plugin's `autoWireDependencies` (the default), step 2 is done for you — you only

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -96,8 +96,8 @@ dependencies {
 ```
 
 `<version>` is a git ref. JitPack looks it up as a tag and falls back to the `v`-prefixed spelling
-when no bare tag exists, so a release resolves either way — `1.2.3` and `v1.2.3` both serve the
-`v1.2.3` build. Prefer the bare form: it is what the docs show, and it matches the version the
+when no bare tag exists, so a release resolves either way — `1.2.4` and `v1.2.4` both serve the
+`v1.2.4` build. Prefer the bare form: it is what the docs show, and it matches the version the
 Gradle plugin carries on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
 `~`, so a `feature/x` branch is `feature~x-SNAPSHOT`. JitPack support starts at **1.1.1**; earlier
 tags do not build there, and bare `1.2.1` is a cached failed build — that one release resolves only

--- a/docs/REMOTE_CONFIG.md
+++ b/docs/REMOTE_CONFIG.md
@@ -29,7 +29,7 @@ debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-
 releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:<version>")
 ```
 
-`<version>` is a JitPack version — `1.2.3` for the current release. Releases are tagged `v1.2.3`,
+`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 // Must share a top-level namespace with the plugin ID (a Plugin Portal requirement) and match
 // the SDK's Maven group.
 group = "io.github.devconsole-android"
-version = "1.2.3"
+version = "1.2.4"
 
 // Targets Java 17: this plugin JAR runs inside the Gradle daemon (AGP 8.13.0
 // requires JDK 17) and compiles against com.android.tools.build:gradle:8.13.0,

--- a/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
@@ -398,10 +398,10 @@ abstract class VerifyDevConsolePackagedArtifactTask : DefaultTask() {
 }
 
 // JitPack serves a build under its git ref name. This repo tags `v*`, and JitPack resolves a
-// requested version against the `v`-prefixed tag when no bare tag exists, so "1.2.3" reaches the
-// v1.2.3 build -- and reads the same as the version this plugin carries on the Plugin Portal.
+// requested version against the `v`-prefixed tag when no bare tag exists, so "1.2.4" reaches the
+// v1.2.4 build -- and reads the same as the version this plugin carries on the Plugin Portal.
 // Bump in step with SDK_VERSION in convention-publishing; the tag must exist before this resolves.
-private const val DEFAULT_SDK_VERSION = "1.2.3"
+private const val DEFAULT_SDK_VERSION = "1.2.4"
 
 /** JitPack's group for this repo — what auto-wiring declares. */
 private const val DEVCONSOLE_GROUP = "com.github.devconsole-android.DevConsole"

--- a/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
@@ -870,12 +870,12 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
         )
 
         // release is PROTECTED by default, so auto-wire adds the noop core coordinate. The published
-        // coordinate is 1.2.3 -- the DEFAULT_SDK_VERSION must not point at a 1.2.3-SNAPSHOT that was
+        // coordinate is 1.2.4 -- the DEFAULT_SDK_VERSION must not point at a 1.2.4-SNAPSHOT that was
         // never published, which would make every zero-config release build fail to resolve.
         val result = runner("dependencies", "--configuration", "releaseImplementation").build()
 
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.3"))
-        assertTrue(result.output, !result.output.contains("1.2.3-SNAPSHOT"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.4"))
+        assertTrue(result.output, !result.output.contains("1.2.4-SNAPSHOT"))
     }
 
     @Test
@@ -925,13 +925,13 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
     @Test
     fun `the JitPack coordinate trips the declared-dependency check`() {
-        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "1.2.3")
+        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "1.2.4")
         writeFixture(
             devConsoleBlock = "autoWireDependencies.set(false)",
             extraBuildScript =
                 """
                 dependencies {
-                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:1.2.3")
+                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:1.2.4")
                 }
                 """.trimIndent(),
         )
@@ -971,7 +971,7 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
         // debug is ENABLED, so the core runtime ("devconsole") must still be auto-wired alongside the
         // host's add-on declaration -- the add-on alone does not count as declaring the core runtime.
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.2.3"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.2.4"))
         assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole-ui-compose"))
     }
 

--- a/samples/compose-app/build.gradle.kts
+++ b/samples/compose-app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.compose"
         versionCode = 1
-        versionName = "1.2.3-SNAPSHOT"
+        versionName = "1.2.4-SNAPSHOT"
     }
 }
 

--- a/samples/compose-app/src/main/AndroidManifest.xml
+++ b/samples/compose-app/src/main/AndroidManifest.xml
@@ -5,6 +5,23 @@
          confined to src/debug/AndroidManifest.xml. -->
     <uses-permission android:name="android.permission.INTERNET" />
     <application android:theme="@style/AppTheme" android:label="DevConsole Compose">
+        <!-- Regression guard, not a feature: a real host that shares files (camera capture, image
+             picking) declares exactly this, and the manifest merger keys <provider> nodes by
+             android:name. When sdk:full declared androidx.core.content.FileProvider under that raw
+             AndroidX name too, the two nodes merged into one and failed every such host's debug
+             build on the differing authorities. Keep the raw class name here; a
+             subclass would make this sample stop catching the regression (sdk:full's own provider
+             is io.devconsole.DevConsoleFileProvider). :samples:compose-app:assembleDebug runs in
+             CI, so a reintroduced collision fails there instead of at a consumer. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/sample_file_provider_paths" />
+        </provider>
         <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/samples/compose-app/src/main/res/xml/sample_file_provider_paths.xml
+++ b/samples/compose-app/src/main/res/xml/sample_file_provider_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Paths for this sample's own FileProvider, declared in AndroidManifest.xml. Nothing in the sample
+  shares a file: the provider exists purely to reproduce the shape of a real host app, so see that
+  manifest declaration for why it is here at all.
+-->
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="shared" path="shared/" />
+</paths>

--- a/samples/foundation-app/build.gradle.kts
+++ b/samples/foundation-app/build.gradle.kts
@@ -31,6 +31,6 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample"
         versionCode = 1
-        versionName = "1.2.3-SNAPSHOT"
+        versionName = "1.2.4-SNAPSHOT"
     }
 }

--- a/samples/views-java-app/build.gradle.kts
+++ b/samples/views-java-app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.viewsjava"
         versionCode = 1
-        versionName = "1.2.3-SNAPSHOT"
+        versionName = "1.2.4-SNAPSHOT"
     }
 }
 

--- a/sdk/full/src/main/AndroidManifest.xml
+++ b/sdk/full/src/main/AndroidManifest.xml
@@ -12,16 +12,16 @@
             android:initOrder="100" />
         <!-- Backs the Files screen's Share action (ACTION_SEND). Paths mirror AndroidFileInspector's
              sandbox roots exactly, see res/xml/devconsole_file_provider_paths.xml, so a shared
-             file is always inside a root that inspector already permits browsing. -->
+             file is always inside a root that inspector already permits browsing. The name is an
+             SDK-specific subclass on purpose: the merger keys providers by android:name, so naming
+             androidx.core.content.FileProvider here collided with every host that declares its own
+             (see DevConsoleFileProvider). That subclass hands FileProvider the paths resource
+             itself, so this declaration needs no meta-data child to collide over either. -->
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name="io.devconsole.DevConsoleFileProvider"
             android:authorities="${applicationId}.devconsole.files"
             android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/devconsole_file_provider_paths" />
-        </provider>
+            android:grantUriPermissions="true" />
         <!-- Keep-alive shell for the embedded dashboard server (docs/BACKGROUND_KEEPALIVE.md).
              The SDK deliberately declares NO permissions for it: the host opts in by declaring
              FOREGROUND_SERVICE (+ FOREGROUND_SERVICE_SPECIAL_USE on API 34+) in its own debug

--- a/sdk/full/src/main/kotlin/io/devconsole/DevConsoleFileProvider.kt
+++ b/sdk/full/src/main/kotlin/io/devconsole/DevConsoleFileProvider.kt
@@ -1,0 +1,22 @@
+package io.devconsole
+
+import androidx.core.content.FileProvider
+import io.devconsole.full.R
+
+/**
+ * The SDK's own [FileProvider] subclass, whose only reason to exist is a unique `android:name` in
+ * the merged manifest.
+ *
+ * The manifest merger keys `<provider>` nodes by `android:name`, not by authority, so declaring
+ * `androidx.core.content.FileProvider` directly made this provider and a host-declared one the same
+ * node. Any host that already shares files -- camera capture, image picking, an attachment picker --
+ * then failed its own debug build with a merge conflict on `android:authorities` and on the nested
+ * `android.support.FILE_PROVIDER_PATHS` resource, and the merger's suggested `tools:replace` fix
+ * silently dropped this SDK's authority instead (see FAQ_TROUBLESHOOTING.md). A name no host would
+ * pick removes the collision at the source; the authority itself is unchanged.
+ *
+ * The resource-id constructor (androidx.core 1.7.0+; this module depends on 1.13.1 directly) also
+ * makes the manifest's `<meta-data>` element unnecessary, so the provider declaration carries no
+ * child node that could collide either.
+ */
+internal class DevConsoleFileProvider : FileProvider(R.xml.devconsole_file_provider_paths)

--- a/sdk/full/src/main/res/xml/devconsole_file_provider_paths.xml
+++ b/sdk/full/src/main/res/xml/devconsole_file_provider_paths.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Backs the `${applicationId}.devconsole.files` FileProvider declared in AndroidManifest.xml.
+  Backs the `${applicationId}.devconsole.files` FileProvider declared in AndroidManifest.xml,
+  which reaches this file through DevConsoleFileProvider's resource-id constructor rather than
+  through an `android.support.FILE_PROVIDER_PATHS` meta-data element.
   Each entry mirrors one of AndroidFileInspector's `rootDirs` exactly (see its doc comment: "files",
   "cache", "external-files", "no-backup") so a file the Files screen can browse is always a file
   FileProvider is willing to hand out a content:// URI for, and nothing outside those roots ever is.

--- a/sdk/storage-room/README.md
+++ b/sdk/storage-room/README.md
@@ -9,7 +9,7 @@
 debugImplementation("com.github.devconsole-android.DevConsole:devconsole-storage-room:<version>")
 ```
 
-`<version>` is a JitPack version — `1.2.3` for the current release. Releases are tagged `v1.2.3`,
+`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 


### PR DESCRIPTION
A client hit this on integration: their debug build failed `processProdDebugMainManifest` with a merge conflict between their own `FileProvider` and DevConsole's.

## Cause

The manifest merger keys `<provider>` nodes by `android:name`, not by authority. `sdk:full` declared its Share-sheet provider as `androidx.core.content.FileProvider`, so in any app that already declares a `FileProvider` of its own — camera capture, image picking, an attachment picker — the two collapsed into one node and the merge failed on the differing `android:authorities` and `android.support.FILE_PROVIDER_PATHS` resource.

The merger's suggested `tools:replace="android:authorities"` is a trap: it settles the conflict by dropping `<applicationId>.devconsole.files`, so the Files screen's Share action throws the first time someone taps it.

## Fix

The provider is now `io.devconsole.DevConsoleFileProvider` — `internal`, mirroring `DevConsoleForegroundService`, so `full.api` is unchanged and no `apiDump` is needed. It takes its paths through `FileProvider`'s resource-id constructor, so the declaration carries no meta-data child to collide over either.

The authority is unchanged, so `InspectorDataScreen.shareFileFromPath` needed no edit and no host app has to move.

## Regression guard

None of the three samples declared a `FileProvider`, which is why this reached a consumer. `samples:compose-app` now declares one under the raw AndroidX name for no reason other than to reproduce a host of that shape. `:samples:compose-app:assembleDebug` runs in `verify.yml`, so a reintroduction fails in CI instead of at a consumer.

Verified both directions: restoring the old `android:name` fails `:samples:compose-app:processDebugMainManifest` with the client's exact error, and the merged debug manifest otherwise carries both providers under distinct names.

## Also here

- `docs/FAQ_TROUBLESHOOTING.md` entry, including the one-line workaround for anyone stuck on 1.2.3.
- The 1.2.4 bump across the same 15 files as #16, plus the CHANGELOG section.

`v1.2.4` should be tagged after this merges — `DEFAULT_SDK_VERSION` now points at `1.2.4`, and the tag has to exist before that resolves on JitPack.

## Checks

- `:sdk:full:verifyQuality`, `:samples:compose-app:verifyQuality` — green.
- `./gradlew -p gradle-plugin test` — green (needs `ANDROID_HOME` locally; CI provides it).
- Full `verify.yml` command — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)