### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,18 @@ before it can reach a release. (There was briefly a separate `sdk:plugin-api` mo
 third-party plugin framework; it was removed before ever shipping — see Removed, below — so it never
 joined this list.)
 
-## Unreleased
+## 1.3.0 — 2026-08-24
 
 Captured requests could only ever be discarded by restarting the session, so a long debugging run
 turned the Traffic list into a haystack ([#23](https://github.com/devconsole-android/DevConsole/issues/23)).
 Both operator surfaces can now clear them.
 
-**Version note, deliberately unresolved here:** `NetworkTransactionStore` gains an abstract
-`clear()`. That interface is not documented as a host extension point and nothing outside this repo
-is known to implement it, but under this file's own [policy](#versioning-and-stability-policy) a new
-abstract member is source-breaking for anyone who does. It is in `sdk:network`, not `sdk:api`, so it
-does not automatically read as a major. The number is left for the release decision rather than
-assumed.
+**Why a minor, not a major:** `NetworkTransactionStore` gains an abstract `clear()`, which is
+source-breaking for anyone who implements that interface. It lives in `sdk:network`, not `sdk:api`,
+and this file's [policy](#versioning-and-stability-policy) reserves a major for breaks to `sdk:api`,
+so what sets the number here is the new API this release adds. The interface is not documented as a
+host extension point and nothing outside this repo is known to implement it — but a custom store
+does have to add one method to compile against 1.3.0.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ dependencyResolutionManagement {
 ```kotlin
 plugins {
     id("com.android.application")
-    id("io.github.devconsole-android") version "1.2.4"
+    id("io.github.devconsole-android") version "1.3.0"
 }
 
 dependencies {
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.4")
-    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.4")
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.3.0")
+    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.0")
 }
 ```
 
@@ -376,8 +376,8 @@ Add the adapter — it is not part of the `devconsole` umbrella, so that Firebas
 classpath of an app that doesn't use it:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:1.2.4")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:1.2.4")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:1.3.0")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:1.3.0")
 ```
 
 > These two artifacts first ship in `1.2.0`; earlier versions do not have them.
@@ -452,8 +452,8 @@ You never name those. Every module publishes sources, javadoc, and a POM.
 ### Versions and unreleased code
 
 All 34 library artifacts come from [JitPack](https://jitpack.io/#devconsole-android/DevConsole),
-which builds a ref on demand. Releases are tagged `v1.2.4`, and JitPack resolves a bare version
-against the `v`-prefixed tag, which is why the coordinates above read `1.2.4` — the same spelling
+which builds a ref on demand. Releases are tagged `v1.3.0`, and JitPack resolves a bare version
+against the `v`-prefixed tag, which is why the coordinates above read `1.3.0` — the same spelling
 the Gradle plugin uses on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
 `~`, so a `feature/x` branch is `feature~x-SNAPSHOT` — that is how you try an unreleased fix before
 it ships. JitPack support starts at **1.1.1**; earlier tags do not build there. Two things to

--- a/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
+++ b/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
@@ -74,7 +74,7 @@ class PublishingConventionPlugin : Plugin<Project> {
         // The POM group. JitPack rewrites it to com.github.devconsole-android.DevConsole when it
         // serves a build, so consumers name that group, not this one.
         const val MAVEN_GROUP = "io.github.devconsole-android"
-        const val SDK_VERSION = "1.2.4"
+        const val SDK_VERSION = "1.3.0"
         const val PROJECT_URL = "https://github.com/devconsole-android/DevConsole"
     }
 }

--- a/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
+++ b/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
@@ -37,7 +37,7 @@ devConsole {
     protectedDependencyPaths.set(setOf(":sdk:full"))        // default; override for a differently-pathed module
     failBuildOnUnsafeVariant.set(true)                      // default; false downgrades to a warning
     autoWireDependencies.set(true)                          // default; false to declare coordinates yourself
-    sdkVersion.set("1.2.4")                                 // default; the JitPack version to resolve
+    sdkVersion.set("1.3.0")                                 // default; the JitPack version to resolve
 }
 ```
 

--- a/docs/GETTING_STARTED_COMPOSE.md
+++ b/docs/GETTING_STARTED_COMPOSE.md
@@ -35,7 +35,7 @@ devConsole {
 }
 ```
 
-`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
+`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/docs/GETTING_STARTED_XML_KOTLIN.md
+++ b/docs/GETTING_STARTED_XML_KOTLIN.md
@@ -35,7 +35,7 @@ devConsole {
 }
 ```
 
-`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
+`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
    `v*` release tag:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.4")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.4")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.3.0")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.0")
 ```
 
 If you rely on the plugin's `autoWireDependencies` (the default), step 2 is done for you — you only

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -96,8 +96,8 @@ dependencies {
 ```
 
 `<version>` is a git ref. JitPack looks it up as a tag and falls back to the `v`-prefixed spelling
-when no bare tag exists, so a release resolves either way — `1.2.4` and `v1.2.4` both serve the
-`v1.2.4` build. Prefer the bare form: it is what the docs show, and it matches the version the
+when no bare tag exists, so a release resolves either way — `1.3.0` and `v1.3.0` both serve the
+`v1.3.0` build. Prefer the bare form: it is what the docs show, and it matches the version the
 Gradle plugin carries on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
 `~`, so a `feature/x` branch is `feature~x-SNAPSHOT`. JitPack support starts at **1.1.1**; earlier
 tags do not build there, and bare `1.2.1` is a cached failed build — that one release resolves only

--- a/docs/REMOTE_CONFIG.md
+++ b/docs/REMOTE_CONFIG.md
@@ -29,7 +29,7 @@ debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-
 releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:<version>")
 ```
 
-`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
+`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 // Must share a top-level namespace with the plugin ID (a Plugin Portal requirement) and match
 // the SDK's Maven group.
 group = "io.github.devconsole-android"
-version = "1.2.4"
+version = "1.3.0"
 
 // Targets Java 17: this plugin JAR runs inside the Gradle daemon (AGP 8.13.0
 // requires JDK 17) and compiles against com.android.tools.build:gradle:8.13.0,

--- a/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
@@ -398,10 +398,10 @@ abstract class VerifyDevConsolePackagedArtifactTask : DefaultTask() {
 }
 
 // JitPack serves a build under its git ref name. This repo tags `v*`, and JitPack resolves a
-// requested version against the `v`-prefixed tag when no bare tag exists, so "1.2.4" reaches the
-// v1.2.4 build -- and reads the same as the version this plugin carries on the Plugin Portal.
+// requested version against the `v`-prefixed tag when no bare tag exists, so "1.3.0" reaches the
+// v1.3.0 build -- and reads the same as the version this plugin carries on the Plugin Portal.
 // Bump in step with SDK_VERSION in convention-publishing; the tag must exist before this resolves.
-private const val DEFAULT_SDK_VERSION = "1.2.4"
+private const val DEFAULT_SDK_VERSION = "1.3.0"
 
 /** JitPack's group for this repo — what auto-wiring declares. */
 private const val DEVCONSOLE_GROUP = "com.github.devconsole-android.DevConsole"

--- a/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
@@ -870,12 +870,12 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
         )
 
         // release is PROTECTED by default, so auto-wire adds the noop core coordinate. The published
-        // coordinate is 1.2.4 -- the DEFAULT_SDK_VERSION must not point at a 1.2.4-SNAPSHOT that was
+        // coordinate is 1.3.0 -- the DEFAULT_SDK_VERSION must not point at a 1.3.0-SNAPSHOT that was
         // never published, which would make every zero-config release build fail to resolve.
         val result = runner("dependencies", "--configuration", "releaseImplementation").build()
 
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.4"))
-        assertTrue(result.output, !result.output.contains("1.2.4-SNAPSHOT"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.0"))
+        assertTrue(result.output, !result.output.contains("1.3.0-SNAPSHOT"))
     }
 
     @Test
@@ -925,13 +925,13 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
     @Test
     fun `the JitPack coordinate trips the declared-dependency check`() {
-        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "1.2.4")
+        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "1.3.0")
         writeFixture(
             devConsoleBlock = "autoWireDependencies.set(false)",
             extraBuildScript =
                 """
                 dependencies {
-                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:1.2.4")
+                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:1.3.0")
                 }
                 """.trimIndent(),
         )
@@ -971,7 +971,7 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
         // debug is ENABLED, so the core runtime ("devconsole") must still be auto-wired alongside the
         // host's add-on declaration -- the add-on alone does not count as declaring the core runtime.
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.2.4"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.3.0"))
         assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole-ui-compose"))
     }
 

--- a/samples/compose-app/build.gradle.kts
+++ b/samples/compose-app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.compose"
         versionCode = 1
-        versionName = "1.2.4-SNAPSHOT"
+        versionName = "1.3.0-SNAPSHOT"
     }
 }
 

--- a/samples/foundation-app/build.gradle.kts
+++ b/samples/foundation-app/build.gradle.kts
@@ -31,6 +31,6 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample"
         versionCode = 1
-        versionName = "1.2.4-SNAPSHOT"
+        versionName = "1.3.0-SNAPSHOT"
     }
 }

--- a/samples/views-java-app/build.gradle.kts
+++ b/samples/views-java-app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.viewsjava"
         versionCode = 1
-        versionName = "1.2.4-SNAPSHOT"
+        versionName = "1.3.0-SNAPSHOT"
     }
 }
 

--- a/sdk/storage-room/README.md
+++ b/sdk/storage-room/README.md
@@ -9,7 +9,7 @@
 debugImplementation("com.github.devconsole-android.DevConsole:devconsole-storage-room:<version>")
 ```
 
-`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
+`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 


### PR DESCRIPTION
## What

Cuts **1.3.0**. Bumps `SDK_VERSION`, the Gradle plugin `version`, `DEFAULT_SDK_VERSION`, the three
sample `versionName`s, and every consumer-facing coordinate in the docs from 1.2.4, then closes out
the CHANGELOG's `Unreleased` section.

**Why a minor, not a major.** The CHANGELOG deliberately left this number open ("left for the
release decision rather than assumed"). The release adds public API — `InspectorDataSource
.clearTransactions()`, `InspectorAction.ClearTransactions`, and `DELETE /api/v1/network/transactions`
— which the [versioning policy](https://github.com/devconsole-android/DevConsole/blob/main/CHANGELOG.md#versioning-and-stability-policy) says
requires a minor. `NetworkTransactionStore`'s new abstract `clear()` *is* source-breaking for an
external implementor, but it sits in `sdk:network`, not `sdk:api`, and the policy reserves a major
for breaks to `sdk:api`. The CHANGELOG now records that reasoning in place of the open question.

One deliberate non-change: the FileProvider entry in `docs/FAQ_TROUBLESHOOTING.md` keeps its
`1.2.4`/`1.2.3` spellings. That paragraph is a historical statement about when the fix landed, not a
pointer at the current release, so bumping it would have made it wrong.

## Verification

Run with `ANDROID_HOME` set (the plugin's functional tests `error()` out without it).

- [x] `./gradlew testDebugUnitTest` — passing
- [x] `./gradlew -p gradle-plugin test` — 32/32 passing (this is the suite the bump actually touches)
- [x] `./gradlew apiCheck` — clean; no API change in this diff, so no `apiDump` needed
- [x] `./gradlew publishToMavenLocal` — passing; all 34 artifacts resolve at 1.3.0, POM version confirmed
- [ ] `./gradlew ktlintCheck detekt` — **fails, but identically on `main`** (verified by re-running on
      `main`): 3 detekt findings and 2 ktlint findings in `samples/compose-app/MainActivity.kt`,
      `samples/foundation-app/MainActivity.kt`, and `sdk/server-api/LocalServerEngine.kt` — all source
      files this diff does not touch, all from 69d3414. Left alone to keep this PR to one logical
      change; they want their own fix before the tag goes out.

Not run: sample assemble/verify — this diff touches no debug/release or protected-variant boundary.

## Checklist

- [x] Capture-path code (network/socket/push) never throws into the host app — no capture-path code changed
- [x] No new sensitive data is captured, logged, or exported — no behavior changed
- [x] Docs updated — every versioned coordinate across README, `docs/`, and `sdk/storage-room/README.md`
- [x] This PR is scoped to one logical change

## Anything reviewers should look at closely

The version number itself — 1.3.0 over 2.0.0 — is the one real judgment call here, and the
`NetworkTransactionStore.clear()` reasoning above is where to push back if you read that break as
major-worthy.

Worth deciding separately: the pre-existing lint failures on `main` mean CI is red on this branch
through no fault of the diff, and the release checklist wants a green build before the tag.
