### PR TITLE
Release/1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,18 @@ before it can reach a release. (There was briefly a separate `sdk:plugin-api` mo
 third-party plugin framework; it was removed before ever shipping — see Removed, below — so it never
 joined this list.)
 
-## Unreleased
+## 1.3.0 — 2026-08-24
 
 Captured requests could only ever be discarded by restarting the session, so a long debugging run
 turned the Traffic list into a haystack ([#23](https://github.com/devconsole-android/DevConsole/issues/23)).
 Both operator surfaces can now clear them.
 
-**Version note, deliberately unresolved here:** `NetworkTransactionStore` gains an abstract
-`clear()`. That interface is not documented as a host extension point and nothing outside this repo
-is known to implement it, but under this file's own [policy](#versioning-and-stability-policy) a new
-abstract member is source-breaking for anyone who does. It is in `sdk:network`, not `sdk:api`, so it
-does not automatically read as a major. The number is left for the release decision rather than
-assumed.
+**Why a minor, not a major:** `NetworkTransactionStore` gains an abstract `clear()`, which is
+source-breaking for anyone who implements that interface. It lives in `sdk:network`, not `sdk:api`,
+and this file's [policy](#versioning-and-stability-policy) reserves a major for breaks to `sdk:api`,
+so what sets the number here is the new API this release adds. The interface is not documented as a
+host extension point and nothing outside this repo is known to implement it — but a custom store
+does have to add one method to compile against 1.3.0.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,26 @@ assumed.
   new route could not otherwise reach it. Left abstract rather than given a no-op default: a custom
   store that silently declined to clear would fail invisibly, which is worse than failing to compile.
 
+- **The protected-artifact verifier is now one task per protected variant**, named
+  `verify<Variant>DevConsoleProtectedArtifacts`. `verifyDevConsoleProtectedArtifacts` survives as an
+  aggregate that depends on all of them, so `check`, the sample apps' CI invocations, and any host
+  release script that names it keep working unchanged. A host that wants to verify one variant on its
+  own can now ask for that variant's task by name.
+
+### Fixed
+
+- **Building one flavor's release no longer builds every other flavor's release.** The verifier used
+  to be a single task holding *every* protected variant's runtime classpath and packaged APK/AAB as
+  its own task inputs, and it was wired onto each protected variant's `assemble`/`bundle`. On a
+  flavored project that meant `assembleProductionRelease` pulled
+  `verifyStagingReleaseDevConsolePackagedArtifact` into the graph, which in turn pulled
+  `dexBuilderStagingRelease`, `bundleStagingRelease` and the rest — so the build resolved and
+  downloaded every other flavor's dependencies, and produced artifacts nobody asked for. A host whose
+  flavors carry environment-specific SDK coordinates saw its production build reach for
+  internal-only artifacts and stall or fail when that repository was unreachable. Splitting the
+  verifier per variant keeps each variant's inputs to itself: building `productionRelease` now
+  touches `productionRelease` only, with no loss of enforcement.
+
 ## 1.2.4 — 2026-08-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ dependencyResolutionManagement {
 ```kotlin
 plugins {
     id("com.android.application")
-    id("io.github.devconsole-android") version "1.2.4"
+    id("io.github.devconsole-android") version "1.3.0"
 }
 
 dependencies {
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.4")
-    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.4")
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.3.0")
+    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.0")
 }
 ```
 
@@ -376,8 +376,8 @@ Add the adapter — it is not part of the `devconsole` umbrella, so that Firebas
 classpath of an app that doesn't use it:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:1.2.4")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:1.2.4")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:1.3.0")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:1.3.0")
 ```
 
 > These two artifacts first ship in `1.2.0`; earlier versions do not have them.
@@ -452,8 +452,8 @@ You never name those. Every module publishes sources, javadoc, and a POM.
 ### Versions and unreleased code
 
 All 34 library artifacts come from [JitPack](https://jitpack.io/#devconsole-android/DevConsole),
-which builds a ref on demand. Releases are tagged `v1.2.4`, and JitPack resolves a bare version
-against the `v`-prefixed tag, which is why the coordinates above read `1.2.4` — the same spelling
+which builds a ref on demand. Releases are tagged `v1.3.0`, and JitPack resolves a bare version
+against the `v`-prefixed tag, which is why the coordinates above read `1.3.0` — the same spelling
 the Gradle plugin uses on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
 `~`, so a `feature/x` branch is `feature~x-SNAPSHOT` — that is how you try an unreleased fix before
 it ships. JitPack support starts at **1.1.1**; earlier tags do not build there. Two things to

--- a/README.md
+++ b/README.md
@@ -488,10 +488,80 @@ Don't take the table's word for it. Check any build yourself:
 aapt2 dump permissions app/build/outputs/apk/release/app-release.apk
 ```
 
-The Gradle plugin enforces the same split mechanically. `verifyDevConsoleProtectedArtifacts` fails
-the build if the full runtime reaches a protected variant, checking declared dependencies, the
+The Gradle plugin enforces the same split mechanically. `verify<Variant>DevConsoleProtectedArtifacts`
+fails the build if the full runtime reaches a protected variant, checking declared dependencies, the
 resolved runtime classpath, and the final APK/AAB bytes. See
 [Build variants and production safety](docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md).
+
+## Flavored projects: verify the variant you ship
+
+**If your app has product flavors, read this before wiring the plugin into a release pipeline.**
+
+By default every non-debug variant is `PROTECTED`, so a project with `production`, `staging`, and
+`partner` flavors gets three protected release variants and three verifiers:
+
+```
+verifyProductionReleaseDevConsoleProtectedArtifacts
+verifyStagingReleaseDevConsoleProtectedArtifacts
+verifyPartnerReleaseDevConsoleProtectedArtifacts
+```
+
+Each one is wired onto **its own** `assemble<Variant>` / `bundle<Variant>` and nothing else, so
+`./gradlew :app:assembleProductionRelease` verifies `productionRelease` and resolves
+`productionRelease`'s classpath — no other flavor is touched. That matters most when your flavors
+carry environment-specific coordinates:
+
+```groovy
+productionImplementation "com.example.sdk:analytics-production-release:1.8.0"
+stagingImplementation    "com.example.sdk:analytics-staging-release:1.8.0"
+partnerImplementation    "com.example.sdk:analytics-partner-release:1.8.0"
+```
+
+A production build must never reach for another environment's artifacts — especially when those live
+in a repository only reachable from an internal network. It doesn't.
+
+The aggregate `verifyDevConsoleProtectedArtifacts` still exists and still verifies **every** protected
+variant — that is its job, and `check` depends on it. On the project above it therefore resolves and
+builds all three release variants. Use it in a CI job that is meant to cover everything; don't put it
+on the critical path of a single-flavor release build:
+
+```bash
+./gradlew :app:assembleProductionRelease                            # ships production, verifies production
+./gradlew :app:verifyProductionReleaseDevConsoleProtectedArtifacts  # the same check on its own
+./gradlew :app:verifyDevConsoleProtectedArtifacts                   # full sweep, all flavors, CI
+```
+
+### Upgrading from 1.2.4 or earlier
+
+Up to and including 1.2.4 there was one shared verifier task carrying every protected variant's
+inputs, wired onto every protected variant's `assemble`/`bundle`. Building one flavor's release
+therefore built all of them. If you recognise any of these, that was the cause and this release fixes
+it:
+
+- a single-flavor release build downloading another flavor's dependencies
+- `assembleProductionRelease` running `dexBuilderStagingRelease`, `bundlePartnerRelease`, or similar
+- a release build failing or hanging on a repository only one flavor's artifacts live in
+- release builds several times slower than the flavor being shipped could explain
+
+No migration is needed — the task name your scripts and CI already call still works, it is now the
+aggregate. If you worked around this by excluding the verifier (`-x verifyDevConsoleProtectedArtifacts`)
+or by narrowing `protectedVariantPatterns` to one flavor, undo it: those workarounds bought speed by
+dropping enforcement, and you no longer have to pay for one with the other.
+
+### Narrowing what gets protected
+
+If you genuinely want fewer protected variants — a flavor whose release build is never distributed,
+say — lower the default and name what you protect. Understand that a variant left out is a variant
+nobody checks:
+
+```kotlin
+devConsole {
+    defaultPolicy.set(DevConsoleVariantPolicy.DISABLED)
+    protectedVariantPatterns.set(listOf("(?i)production.*release"))
+}
+```
+
+`DISABLED` variants still get `devconsole-noop` auto-wired — they simply are not verified.
 
 ## Security model
 

--- a/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
+++ b/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
@@ -74,7 +74,7 @@ class PublishingConventionPlugin : Plugin<Project> {
         // The POM group. JitPack rewrites it to com.github.devconsole-android.DevConsole when it
         // serves a build, so consumers name that group, not this one.
         const val MAVEN_GROUP = "io.github.devconsole-android"
-        const val SDK_VERSION = "1.2.4"
+        const val SDK_VERSION = "1.3.0"
         const val PROJECT_URL = "https://github.com/devconsole-android/DevConsole"
     }
 }

--- a/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
+++ b/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
@@ -65,17 +65,30 @@ artifact, but only `PROTECTED` variants fail the build if the full runtime shows
 
 ## `devConsoleVariantReport` and `verifyDevConsoleProtectedArtifacts`
 
-Two tasks come with the plugin:
+The plugin registers:
 
 - `devConsoleVariantReport` writes `build/reports/devconsole/variants.json` listing the effective
   policy (`ENABLED`/`DISABLED`/`PROTECTED`) for every variant.
-- `verifyDevConsoleProtectedArtifacts` inspects each protected variant's dependency graph for a
-  direct `ProjectDependency` on any path in `protectedDependencyPaths`, and fails the build if one
-  is found. Run it as part of your release checklist — the three sample apps run it in CI on every
-  push (see [`.github/workflows/verify.yml`](../.github/workflows/verify.yml)).
+- `verify<Variant>DevConsoleProtectedArtifacts` — one task per protected variant — inspects that
+  variant's dependency graph for a direct `ProjectDependency` on any path in
+  `protectedDependencyPaths`, and fails the build if one is found. Each variant's
+  `assemble<Variant>` and `bundle<Variant>` depends on its own verifier, so building a protected
+  artifact always runs its checks.
+- `verifyDevConsoleProtectedArtifacts` is the aggregate: it depends on every per-variant verifier,
+  and `check` hangs off it. Run it as part of your release checklist — the three sample apps run it
+  in CI on every push (see [`.github/workflows/verify.yml`](../.github/workflows/verify.yml)).
 
 ```bash
 ./gradlew :app:assembleRelease :app:verifyDevConsoleProtectedArtifacts
+```
+
+On a flavored project, ask for the variant you are actually shipping. The aggregate verifies *every*
+protected variant, so on a project with `production`/`staging`/`partner` flavors it resolves — and
+builds — all three release variants:
+
+```bash
+./gradlew :app:assembleProductionRelease                              # verifies productionRelease only
+./gradlew :app:verifyProductionReleaseDevConsoleProtectedArtifacts    # the same check, on its own
 ```
 
 ## Full/no-op parity

--- a/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
+++ b/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
@@ -37,7 +37,7 @@ devConsole {
     protectedDependencyPaths.set(setOf(":sdk:full"))        // default; override for a differently-pathed module
     failBuildOnUnsafeVariant.set(true)                      // default; false downgrades to a warning
     autoWireDependencies.set(true)                          // default; false to declare coordinates yourself
-    sdkVersion.set("1.2.4")                                 // default; the JitPack version to resolve
+    sdkVersion.set("1.3.0")                                 // default; the JitPack version to resolve
 }
 ```
 

--- a/docs/FAQ_TROUBLESHOOTING.md
+++ b/docs/FAQ_TROUBLESHOOTING.md
@@ -30,6 +30,17 @@ dashboard assets, and storage layer live only in `sdk:full`, and `verifyDevConso
 checks specifically for a dependency on that module, not for the absence of every DevConsole class.
 See [BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md](BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md).
 
+**Why is my release build downloading another flavor's dependencies?** Up to 1.2.4 the plugin
+registered a single `verifyDevConsoleProtectedArtifacts` task holding *every* protected variant's
+runtime classpath and packaged artifact as its own inputs, and wired it onto each protected variant's
+`assemble`/`bundle` — so `assembleProductionRelease` dragged `dexBuilderStagingRelease`,
+`bundlePartnerRelease` and every other flavor's dependency download into the graph. Since then there
+is one verifier per variant (`verifyProductionReleaseDevConsoleProtectedArtifacts`), each wired only
+onto its own variant's tasks, and `verifyDevConsoleProtectedArtifacts` is an aggregate you invoke
+deliberately.
+Upgrade, and drop any `-x verifyDevConsoleProtectedArtifacts` workaround. See the flavored-projects
+section in the [README](../README.md#flavored-projects-verify-the-variant-you-ship).
+
 **I toggled a feature flag in the dashboard but my app didn't change.** Flags are pulled, not
 pushed. Call `DevConsole.featureFlagValue(key)` wherever you'd otherwise check a local flag. There
 is no change notification, so re-check after whatever user action would plausibly follow a QA

--- a/docs/GETTING_STARTED_COMPOSE.md
+++ b/docs/GETTING_STARTED_COMPOSE.md
@@ -35,7 +35,7 @@ devConsole {
 }
 ```
 
-`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
+`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/docs/GETTING_STARTED_XML_KOTLIN.md
+++ b/docs/GETTING_STARTED_XML_KOTLIN.md
@@ -35,7 +35,7 @@ devConsole {
 }
 ```
 
-`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
+`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
    `v*` release tag:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.2.4")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.4")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.3.0")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.0")
 ```
 
 If you rely on the plugin's `autoWireDependencies` (the default), step 2 is done for you — you only

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -96,8 +96,8 @@ dependencies {
 ```
 
 `<version>` is a git ref. JitPack looks it up as a tag and falls back to the `v`-prefixed spelling
-when no bare tag exists, so a release resolves either way — `1.2.4` and `v1.2.4` both serve the
-`v1.2.4` build. Prefer the bare form: it is what the docs show, and it matches the version the
+when no bare tag exists, so a release resolves either way — `1.3.0` and `v1.3.0` both serve the
+`v1.3.0` build. Prefer the bare form: it is what the docs show, and it matches the version the
 Gradle plugin carries on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
 `~`, so a `feature/x` branch is `feature~x-SNAPSHOT`. JitPack support starts at **1.1.1**; earlier
 tags do not build there, and bare `1.2.1` is a cached failed build — that one release resolves only

--- a/docs/REMOTE_CONFIG.md
+++ b/docs/REMOTE_CONFIG.md
@@ -29,7 +29,7 @@ debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-
 releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:<version>")
 ```
 
-`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
+`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 // Must share a top-level namespace with the plugin ID (a Plugin Portal requirement) and match
 // the SDK's Maven group.
 group = "io.github.devconsole-android"
-version = "1.2.4"
+version = "1.3.0"
 
 // Targets Java 17: this plugin JAR runs inside the Gradle daemon (AGP 8.13.0
 // requires JDK 17) and compiles against com.android.tools.build:gradle:8.13.0,

--- a/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
@@ -418,7 +418,7 @@ private val CORE_RUNTIME_COORDINATE_NAMES = setOf("devconsole", "devconsole-noop
 
 class DevConsoleVariantPolicyPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
-        val packagedVerificationTasks = mutableListOf<TaskProvider<VerifyDevConsolePackagedArtifactTask>>()
+        val packagedVerificationTasks = linkedMapOf<String, TaskProvider<VerifyDevConsolePackagedArtifactTask>>()
         // variant name -> AGP build type name (e.g. "productionDebug" -> "debug"). Populated by the
         // AndroidComponentsExtension#onVariants callbacks in registerPackagedArtifactScans below. The
         // build type is what lets a flavored variant like "productionDebug" resolve against
@@ -514,7 +514,7 @@ class DevConsoleVariantPolicyPlugin : Plugin<Project> {
 
     private fun Project.registerPackagedArtifactScans(
         extension: DevConsoleExtension,
-        scans: MutableList<TaskProvider<VerifyDevConsolePackagedArtifactTask>>,
+        scans: MutableMap<String, TaskProvider<VerifyDevConsolePackagedArtifactTask>>,
         actualVariantBuildTypes: MutableMap<String, String?>,
     ) {
         plugins.withId("com.android.application") {
@@ -525,7 +525,7 @@ class DevConsoleVariantPolicyPlugin : Plugin<Project> {
                     if (variantPolicy(variant.name, variant.buildType, extension) != DevConsoleVariantPolicy.PROTECTED) {
                         return@onVariants
                     }
-                    scans +=
+                    scans[variant.name] =
                         tasks.register<VerifyDevConsolePackagedArtifactTask>(
                             "verify${variant.name.capitalized()}DevConsolePackagedArtifact",
                         ) {
@@ -551,7 +551,7 @@ class DevConsoleVariantPolicyPlugin : Plugin<Project> {
                     if (variantPolicy(variant.name, variant.buildType, extension) != DevConsoleVariantPolicy.PROTECTED) {
                         return@onVariants
                     }
-                    scans +=
+                    scans[variant.name] =
                         tasks.register<VerifyDevConsolePackagedArtifactTask>(
                             "verify${variant.name.capitalized()}DevConsolePackagedArtifact",
                         ) {
@@ -677,81 +677,106 @@ class DevConsoleVariantPolicyPlugin : Plugin<Project> {
         policies: Map<String, DevConsoleVariantPolicy>,
         report: TaskProvider<DevConsoleVariantReportTask>,
         extension: DevConsoleExtension,
-        packagedVerificationTasks: List<TaskProvider<VerifyDevConsolePackagedArtifactTask>>,
+        packagedVerificationTasks: Map<String, TaskProvider<VerifyDevConsolePackagedArtifactTask>>,
     ) {
         val protectedPaths = extension.protectedDependencyPaths.get()
         val protectedVariants = policies.filterValues { it == DevConsoleVariantPolicy.PROTECTED }.keys
-        val violations = protectedVariants.flatMap { variant ->
-            val variantConfig = configurations.findByName("${variant}Implementation")
-            val implConfig = configurations.findByName("implementation")
-            val allDeps = (variantConfig?.dependencies.orEmpty() + implConfig?.dependencies.orEmpty())
-            allDeps.mapNotNull { dep ->
-                when {
-                    dep is ProjectDependency -> {
-                        val path = dep.projectPathCompat()
-                        if (path in protectedPaths) "$variant -> $path" else null
-                    }
-                    dep is org.gradle.api.artifacts.ExternalModuleDependency && dep.group in DEVCONSOLE_GROUPS && dep.name == "devconsole" -> "$variant -> ${dep.group}:${dep.name}"
-                    else -> null
-                }
+        // One verifier task per protected variant, never a single shared one. A shared task carries
+        // every protected variant's runtime classpath and packaged artifact as its own inputs, so
+        // wiring it onto assemble<Variant> made building one variant resolve -- and on a flavored
+        // project fully build -- every other protected variant too: `assembleProductionRelease`
+        // dragged `dexBuilderStagingRelease`, `bundleStagingRelease` and every other flavor's
+        // dependency download into the graph. Per-variant tasks keep each variant's inputs to itself.
+        val verifiers = protectedVariants.map { variant ->
+            val verifier = tasks.register<VerifyDevConsoleProtectedArtifactsTask>(
+                "verify${variant.capitalized()}DevConsoleProtectedArtifacts",
+            ) {
+                group = "verification"
+                dependsOn(report)
+                packagedVerificationTasks[variant]?.let { packaged -> dependsOn(packaged) }
+                violations.set(declaredViolations(variant, protectedPaths))
+                resolvedRuntimeComponents.put(variant, resolvedRuntimeComponents(variant))
+                protectedProjectPaths.set(protectedPaths)
+                failOnUnsafeVariant.set(extension.failBuildOnUnsafeVariant)
             }
-        }
-        // Walk each protected variant's runtime dependency *graph* lazily (at task execution) so
-        // transitive inclusion of the full runtime is caught too. The graph (resolutionResult) yields
-        // component identities without resolving artifact files, which for an Android classpath is
-        // ambiguous across artifact types.
-        val resolvedComponents = protectedVariants.map { variant ->
-            val classpath = configurations.findByName("${variant}RuntimeClasspath")
-                ?: error(
-                    "DevConsole: protected variant '$variant' has no '${variant}RuntimeClasspath' " +
-                        "configuration, so its transitive dependency graph cannot be verified. This " +
-                        "usually means io.github.devconsole-android was applied before " +
-                        "com.android.application (or com.android.library) in the `plugins {}` block, " +
-                        "or '$variant' is a build-type name that does not correspond to a real " +
-                        "variant on a flavored project (e.g. 'release' instead of " +
-                        "'productionRelease'). Apply com.android.application (or com.android.library) " +
-                        "before io.github.devconsole-android, or ensure enabledVariants / " +
-                        "protectedVariantPatterns reference actual variant names.",
-                )
-            variant to classpath.incoming.resolutionResult.rootComponent.map { root ->
-                val seen = linkedSetOf<String>()
-                val queue = ArrayDeque(root.dependencies)
-                while (queue.isNotEmpty()) {
-                    val dependency = queue.removeFirst() as? ResolvedDependencyResult ?: continue
-                    val selected = dependency.selected
-                    val identity =
-                        when (val componentId = selected.id) {
-                            is ProjectComponentIdentifier -> "project ${componentId.projectPath}"
-                            else -> componentId.displayName
-                        }
-                    if (seen.add(identity)) queue.addAll(selected.dependencies)
-                }
-                seen.toList()
-            }
-        }
-        val verifier = tasks.register<VerifyDevConsoleProtectedArtifactsTask>("verifyDevConsoleProtectedArtifacts") {
-            group = "verification"
-            dependsOn(report)
-            dependsOn(packagedVerificationTasks)
-            this.violations.set(violations)
-            resolvedComponents.forEach { (variant, provider) -> resolvedRuntimeComponents.put(variant, provider) }
-            protectedProjectPaths.set(protectedPaths)
-            this.failOnUnsafeVariant.set(extension.failBuildOnUnsafeVariant)
-        }
-        tasks.findByName("check")?.let { checkTask ->
-            checkTask.dependsOn(verifier)
-        }
-        // `check` alone is not enough: `./gradlew bundleRelease && upload` (or `assembleRelease`)
-        // never runs `check` and previously got zero enforcement. Wire the verifier as a dependency of
-        // every protected variant's assemble<Variant>/bundle<Variant> task too, so building the
-        // protected artifact itself always runs the checks. tasks.matching { }.configureEach { } is
-        // lazy and safe even when a task name does not exist for this project type (e.g.
-        // bundle<Variant> on a library module, which has no bundle task) -- it never forces the task
-        // to be created, it just configures it if and when it is.
-        protectedVariants.forEach { variant ->
+            // `check` alone is not enough: `./gradlew bundleRelease && upload` (or `assembleRelease`)
+            // never runs `check` and previously got zero enforcement. Wire the verifier as a dependency
+            // of this variant's own assemble<Variant>/bundle<Variant> task too, so building the
+            // protected artifact itself always runs the checks. tasks.matching { }.configureEach { } is
+            // lazy and safe even when a task name does not exist for this project type (e.g.
+            // bundle<Variant> on a library module, which has no bundle task) -- it never forces the task
+            // to be created, it just configures it if and when it is.
             val capitalized = variant.capitalized()
             tasks.matching { it.name == "assemble$capitalized" }.configureEach { it.dependsOn(verifier) }
             tasks.matching { it.name == "bundle$capitalized" }.configureEach { it.dependsOn(verifier) }
+            verifier
+        }
+        // Aggregate lifecycle task: the name hosts and CI already invoke, and what `check` hangs off.
+        // Asking for it explicitly still verifies every protected variant -- it just is no longer on
+        // any single variant's build path.
+        val aggregate = tasks.register("verifyDevConsoleProtectedArtifacts") { task ->
+            task.group = "verification"
+            task.description = "Verifies every protected variant excludes the full DevConsole runtime."
+            task.dependsOn(verifiers)
+        }
+        tasks.findByName("check")?.let { checkTask ->
+            checkTask.dependsOn(aggregate)
+        }
+    }
+
+    /** Violations found among a protected variant's *declared* dependencies. */
+    private fun Project.declaredViolations(
+        variant: String,
+        protectedPaths: Set<String>,
+    ): List<String> {
+        val variantConfig = configurations.findByName("${variant}Implementation")
+        val implConfig = configurations.findByName("implementation")
+        val allDeps = (variantConfig?.dependencies.orEmpty() + implConfig?.dependencies.orEmpty())
+        return allDeps.mapNotNull { dep ->
+            when {
+                dep is ProjectDependency -> {
+                    val path = dep.projectPathCompat()
+                    if (path in protectedPaths) "$variant -> $path" else null
+                }
+                dep is org.gradle.api.artifacts.ExternalModuleDependency && dep.group in DEVCONSOLE_GROUPS && dep.name == "devconsole" -> "$variant -> ${dep.group}:${dep.name}"
+                else -> null
+            }
+        }
+    }
+
+    /**
+     * Walks a protected variant's runtime dependency *graph* lazily (at task execution) so transitive
+     * inclusion of the full runtime is caught too. The graph (resolutionResult) yields component
+     * identities without resolving artifact files, which for an Android classpath is ambiguous across
+     * artifact types.
+     */
+    private fun Project.resolvedRuntimeComponents(variant: String): org.gradle.api.provider.Provider<List<String>> {
+        val classpath = configurations.findByName("${variant}RuntimeClasspath")
+            ?: error(
+                "DevConsole: protected variant '$variant' has no '${variant}RuntimeClasspath' " +
+                    "configuration, so its transitive dependency graph cannot be verified. This " +
+                    "usually means io.github.devconsole-android was applied before " +
+                    "com.android.application (or com.android.library) in the `plugins {}` block, " +
+                    "or '$variant' is a build-type name that does not correspond to a real " +
+                    "variant on a flavored project (e.g. 'release' instead of " +
+                    "'productionRelease'). Apply com.android.application (or com.android.library) " +
+                    "before io.github.devconsole-android, or ensure enabledVariants / " +
+                    "protectedVariantPatterns reference actual variant names.",
+            )
+        return classpath.incoming.resolutionResult.rootComponent.map { root ->
+            val seen = linkedSetOf<String>()
+            val queue = ArrayDeque(root.dependencies)
+            while (queue.isNotEmpty()) {
+                val dependency = queue.removeFirst() as? ResolvedDependencyResult ?: continue
+                val selected = dependency.selected
+                val identity =
+                    when (val componentId = selected.id) {
+                        is ProjectComponentIdentifier -> "project ${componentId.projectPath}"
+                        else -> componentId.displayName
+                    }
+                if (seen.add(identity)) queue.addAll(selected.dependencies)
+            }
+            seen.toList()
         }
     }
 }

--- a/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
@@ -398,10 +398,10 @@ abstract class VerifyDevConsolePackagedArtifactTask : DefaultTask() {
 }
 
 // JitPack serves a build under its git ref name. This repo tags `v*`, and JitPack resolves a
-// requested version against the `v`-prefixed tag when no bare tag exists, so "1.2.4" reaches the
-// v1.2.4 build -- and reads the same as the version this plugin carries on the Plugin Portal.
+// requested version against the `v`-prefixed tag when no bare tag exists, so "1.3.0" reaches the
+// v1.3.0 build -- and reads the same as the version this plugin carries on the Plugin Portal.
 // Bump in step with SDK_VERSION in convention-publishing; the tag must exist before this resolves.
-private const val DEFAULT_SDK_VERSION = "1.2.4"
+private const val DEFAULT_SDK_VERSION = "1.3.0"
 
 /** JitPack's group for this repo — what auto-wiring declares. */
 private const val DEVCONSOLE_GROUP = "com.github.devconsole-android.DevConsole"

--- a/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
@@ -870,12 +870,12 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
         )
 
         // release is PROTECTED by default, so auto-wire adds the noop core coordinate. The published
-        // coordinate is 1.2.4 -- the DEFAULT_SDK_VERSION must not point at a 1.2.4-SNAPSHOT that was
+        // coordinate is 1.3.0 -- the DEFAULT_SDK_VERSION must not point at a 1.3.0-SNAPSHOT that was
         // never published, which would make every zero-config release build fail to resolve.
         val result = runner("dependencies", "--configuration", "releaseImplementation").build()
 
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:1.2.4"))
-        assertTrue(result.output, !result.output.contains("1.2.4-SNAPSHOT"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.0"))
+        assertTrue(result.output, !result.output.contains("1.3.0-SNAPSHOT"))
     }
 
     @Test
@@ -925,13 +925,13 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
     @Test
     fun `the JitPack coordinate trips the declared-dependency check`() {
-        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "1.2.4")
+        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "1.3.0")
         writeFixture(
             devConsoleBlock = "autoWireDependencies.set(false)",
             extraBuildScript =
                 """
                 dependencies {
-                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:1.2.4")
+                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:1.3.0")
                 }
                 """.trimIndent(),
         )
@@ -971,7 +971,7 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
         // debug is ENABLED, so the core runtime ("devconsole") must still be auto-wired alongside the
         // host's add-on declaration -- the add-on alone does not count as declaring the core runtime.
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.2.4"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.3.0"))
         assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole-ui-compose"))
     }
 

--- a/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
@@ -517,7 +517,7 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
         val result = runner("bundleRelease").buildAndFail()
 
-        assertTrue(result.output, result.output.contains(":verifyDevConsoleProtectedArtifacts"))
+        assertTrue(result.output, result.output.contains(":verifyReleaseDevConsoleProtectedArtifacts"))
         assertTrue(result.output, result.output.contains("release -> :stub-full"))
     }
 
@@ -973,6 +973,36 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
         // host's add-on declaration -- the add-on alone does not count as declaring the core runtime.
         assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.2.4"))
         assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole-ui-compose"))
+    }
+
+    @Test
+    fun `assembling one flavor's release keeps another flavor's release out of the task graph`() {
+        writeFixture(
+            devConsoleBlock = "",
+            androidPlugin = "com.android.application",
+            applicationIdLine =
+                """
+                applicationId = "io.devconsole.fixture"
+                versionCode = 1
+                """.trimIndent(),
+            androidBlock =
+                """
+                flavorDimensions += "environment"
+                productFlavors {
+                    create("production") { dimension = "environment" }
+                    create("partner") { dimension = "environment" }
+                }
+                """.trimIndent(),
+        )
+
+        val result = runner("assembleProductionRelease", "--dry-run").build()
+
+        assertTrue(result.output, result.output.contains(":verifyProductionReleaseDevConsoleProtectedArtifacts"))
+        assertTrue(result.output, result.output.contains(":verifyProductionReleaseDevConsolePackagedArtifact"))
+        // A single shared verifier task holding every protected variant's runtime classpath and
+        // packaged artifact as inputs made assembling one flavor resolve -- and build -- every other
+        // flavor's release variant too.
+        assertTrue(result.output, !result.output.contains("PartnerRelease"))
     }
 
     private companion object {

--- a/samples/compose-app/build.gradle.kts
+++ b/samples/compose-app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.compose"
         versionCode = 1
-        versionName = "1.2.4-SNAPSHOT"
+        versionName = "1.3.0-SNAPSHOT"
     }
 }
 

--- a/samples/foundation-app/build.gradle.kts
+++ b/samples/foundation-app/build.gradle.kts
@@ -31,6 +31,6 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample"
         versionCode = 1
-        versionName = "1.2.4-SNAPSHOT"
+        versionName = "1.3.0-SNAPSHOT"
     }
 }

--- a/samples/views-java-app/build.gradle.kts
+++ b/samples/views-java-app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.viewsjava"
         versionCode = 1
-        versionName = "1.2.4-SNAPSHOT"
+        versionName = "1.3.0-SNAPSHOT"
     }
 }
 

--- a/sdk/storage-room/README.md
+++ b/sdk/storage-room/README.md
@@ -9,7 +9,7 @@
 debugImplementation("com.github.devconsole-android.DevConsole:devconsole-storage-room:<version>")
 ```
 
-`<version>` is a JitPack version — `1.2.4` for the current release. Releases are tagged `v1.2.4`,
+`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 


### PR DESCRIPTION
## What

One or two sentences on what changed and why (the "why" matters more than the "what" — the diff
already shows the what).

## Verification

Which `./gradlew` commands did you run, and what did they confirm? (See
[CONTRIBUTING.md](../CONTRIBUTING.md#building-and-testing) for the standard set.)

- [ ] `./gradlew testDebugUnitTest` — passing
- [ ] `./gradlew ktlintCheck detekt` — clean (or new detekt findings are justified, not baselined away)
- [ ] `./gradlew apiCheck` — clean, or `apiDump` is included in this diff because the public API changed
- [ ] If this touches a debug/release or protected-variant boundary: sample assemble/verify commands
      run for the affected sample(s) (`:samples:<name>:assembleRelease
      :samples:<name>:verifyDevConsoleProtectedArtifacts`)

## Checklist

- [ ] Capture-path code (network/socket/push) never throws into the host app
- [ ] No new sensitive data is captured, logged, or exported without going through
      `RedactionEngine` first
- [ ] Docs updated if behavior, an API, or a config field changed
      (see [docs/README.md](../docs/README.md) for the index)
- [ ] This PR is scoped to one logical change

## Anything reviewers should look at closely

Optional — call out anything you're unsure about, a tradeoff you made, or a spot you want a second
look at.
