### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,30 @@ before it can reach a release. (There was briefly a separate `sdk:plugin-api` mo
 third-party plugin framework; it was removed before ever shipping — see Removed, below — so it never
 joined this list.)
 
+## 1.3.1 — 2026-08-24
+
+### Changed
+
+- **The protected-artifact verifier is now one task per protected variant**, named
+  `verify<Variant>DevConsoleProtectedArtifacts`. `verifyDevConsoleProtectedArtifacts` survives as an
+  aggregate that depends on all of them, so `check`, the sample apps' CI invocations, and any host
+  release script that names it keep working unchanged. A host that wants to verify one variant on its
+  own can now ask for that variant's task by name.
+
+### Fixed
+
+- **Building one flavor's release no longer builds every other flavor's release.** The verifier used
+  to be a single task holding *every* protected variant's runtime classpath and packaged APK/AAB as
+  its own task inputs, and it was wired onto each protected variant's `assemble`/`bundle`. On a
+  flavored project that meant `assembleProductionRelease` pulled
+  `verifyStagingReleaseDevConsolePackagedArtifact` into the graph, which in turn pulled
+  `dexBuilderStagingRelease`, `bundleStagingRelease` and the rest — so the build resolved and
+  downloaded every other flavor's dependencies, and produced artifacts nobody asked for. A host whose
+  flavors carry environment-specific SDK coordinates saw its production build reach for
+  internal-only artifacts and stall or fail when that repository was unreachable. Splitting the
+  verifier per variant keeps each variant's inputs to itself: building `productionRelease` now
+  touches `productionRelease` only, with no loss of enforcement.
+
 ## 1.3.0 — 2026-08-24
 
 Captured requests could only ever be discarded by restarting the session, so a long debugging run
@@ -62,26 +86,6 @@ does have to add one method to compile against 1.3.0.
   `InMemoryNetworkTransactionStore`. The Ktor module holds its store through the interface, so the
   new route could not otherwise reach it. Left abstract rather than given a no-op default: a custom
   store that silently declined to clear would fail invisibly, which is worse than failing to compile.
-
-- **The protected-artifact verifier is now one task per protected variant**, named
-  `verify<Variant>DevConsoleProtectedArtifacts`. `verifyDevConsoleProtectedArtifacts` survives as an
-  aggregate that depends on all of them, so `check`, the sample apps' CI invocations, and any host
-  release script that names it keep working unchanged. A host that wants to verify one variant on its
-  own can now ask for that variant's task by name.
-
-### Fixed
-
-- **Building one flavor's release no longer builds every other flavor's release.** The verifier used
-  to be a single task holding *every* protected variant's runtime classpath and packaged APK/AAB as
-  its own task inputs, and it was wired onto each protected variant's `assemble`/`bundle`. On a
-  flavored project that meant `assembleProductionRelease` pulled
-  `verifyStagingReleaseDevConsolePackagedArtifact` into the graph, which in turn pulled
-  `dexBuilderStagingRelease`, `bundleStagingRelease` and the rest — so the build resolved and
-  downloaded every other flavor's dependencies, and produced artifacts nobody asked for. A host whose
-  flavors carry environment-specific SDK coordinates saw its production build reach for
-  internal-only artifacts and stall or fail when that repository was unreachable. Splitting the
-  verifier per variant keeps each variant's inputs to itself: building `productionRelease` now
-  touches `productionRelease` only, with no loss of enforcement.
 
 ## 1.2.4 — 2026-08-20
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ dependencyResolutionManagement {
 ```kotlin
 plugins {
     id("com.android.application")
-    id("io.github.devconsole-android") version "1.3.0"
+    id("io.github.devconsole-android") version "1.3.1"
 }
 
 dependencies {
-    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.3.0")
-    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.0")
+    debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.3.1")
+    releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.1")
 }
 ```
 
@@ -376,8 +376,8 @@ Add the adapter — it is not part of the `devconsole` umbrella, so that Firebas
 classpath of an app that doesn't use it:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:1.3.0")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:1.3.0")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase:1.3.1")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:1.3.1")
 ```
 
 > These two artifacts first ship in `1.2.0`; earlier versions do not have them.
@@ -452,8 +452,8 @@ You never name those. Every module publishes sources, javadoc, and a POM.
 ### Versions and unreleased code
 
 All 34 library artifacts come from [JitPack](https://jitpack.io/#devconsole-android/DevConsole),
-which builds a ref on demand. Releases are tagged `v1.3.0`, and JitPack resolves a bare version
-against the `v`-prefixed tag, which is why the coordinates above read `1.3.0` — the same spelling
+which builds a ref on demand. Releases are tagged `v1.3.1`, and JitPack resolves a bare version
+against the `v`-prefixed tag, which is why the coordinates above read `1.3.1` — the same spelling
 the Gradle plugin uses on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
 `~`, so a `feature/x` branch is `feature~x-SNAPSHOT` — that is how you try an unreleased fix before
 it ships. JitPack support starts at **1.1.1**; earlier tags do not build there. Two things to

--- a/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
+++ b/build-logic/convention-publishing/src/main/kotlin/io/devconsole/buildlogic/PublishingConventionPlugin.kt
@@ -74,7 +74,7 @@ class PublishingConventionPlugin : Plugin<Project> {
         // The POM group. JitPack rewrites it to com.github.devconsole-android.DevConsole when it
         // serves a build, so consumers name that group, not this one.
         const val MAVEN_GROUP = "io.github.devconsole-android"
-        const val SDK_VERSION = "1.3.0"
+        const val SDK_VERSION = "1.3.1"
         const val PROJECT_URL = "https://github.com/devconsole-android/DevConsole"
     }
 }

--- a/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
+++ b/docs/BUILD_VARIANTS_AND_PRODUCTION_SAFETY.md
@@ -37,7 +37,7 @@ devConsole {
     protectedDependencyPaths.set(setOf(":sdk:full"))        // default; override for a differently-pathed module
     failBuildOnUnsafeVariant.set(true)                      // default; false downgrades to a warning
     autoWireDependencies.set(true)                          // default; false to declare coordinates yourself
-    sdkVersion.set("1.3.0")                                 // default; the JitPack version to resolve
+    sdkVersion.set("1.3.1")                                 // default; the JitPack version to resolve
 }
 ```
 

--- a/docs/GETTING_STARTED_COMPOSE.md
+++ b/docs/GETTING_STARTED_COMPOSE.md
@@ -35,7 +35,7 @@ devConsole {
 }
 ```
 
-`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
+`<version>` is a JitPack version — `1.3.1` for the current release. Releases are tagged `v1.3.1`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/docs/GETTING_STARTED_XML_KOTLIN.md
+++ b/docs/GETTING_STARTED_XML_KOTLIN.md
@@ -35,7 +35,7 @@ devConsole {
 }
 ```
 
-`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
+`<version>` is a JitPack version — `1.3.1` for the current release. Releases are tagged `v1.3.1`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
    `v*` release tag:
 
 ```kotlin
-debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.3.0")
-releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.0")
+debugImplementation("com.github.devconsole-android.DevConsole:devconsole:1.3.1")
+releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.1")
 ```
 
 If you rely on the plugin's `autoWireDependencies` (the default), step 2 is done for you — you only

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -96,8 +96,8 @@ dependencies {
 ```
 
 `<version>` is a git ref. JitPack looks it up as a tag and falls back to the `v`-prefixed spelling
-when no bare tag exists, so a release resolves either way — `1.3.0` and `v1.3.0` both serve the
-`v1.3.0` build. Prefer the bare form: it is what the docs show, and it matches the version the
+when no bare tag exists, so a release resolves either way — `1.3.1` and `v1.3.1` both serve the
+`v1.3.1` build. Prefer the bare form: it is what the docs show, and it matches the version the
 Gradle plugin carries on the Portal. Any branch works as `<branch>-SNAPSHOT`, with `/` written as
 `~`, so a `feature/x` branch is `feature~x-SNAPSHOT`. JitPack support starts at **1.1.1**; earlier
 tags do not build there, and bare `1.2.1` is a cached failed build — that one release resolves only

--- a/docs/REMOTE_CONFIG.md
+++ b/docs/REMOTE_CONFIG.md
@@ -29,7 +29,7 @@ debugImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-
 releaseImplementation("com.github.devconsole-android.DevConsole:devconsole-remote-config-firebase-noop:<version>")
 ```
 
-`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
+`<version>` is a JitPack version — `1.3.1` for the current release. Releases are tagged `v1.3.1`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 // Must share a top-level namespace with the plugin ID (a Plugin Portal requirement) and match
 // the SDK's Maven group.
 group = "io.github.devconsole-android"
-version = "1.3.0"
+version = "1.3.1"
 
 // Targets Java 17: this plugin JAR runs inside the Gradle daemon (AGP 8.13.0
 // requires JDK 17) and compiles against com.android.tools.build:gradle:8.13.0,

--- a/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPlugin.kt
@@ -398,10 +398,10 @@ abstract class VerifyDevConsolePackagedArtifactTask : DefaultTask() {
 }
 
 // JitPack serves a build under its git ref name. This repo tags `v*`, and JitPack resolves a
-// requested version against the `v`-prefixed tag when no bare tag exists, so "1.3.0" reaches the
-// v1.3.0 build -- and reads the same as the version this plugin carries on the Plugin Portal.
+// requested version against the `v`-prefixed tag when no bare tag exists, so "1.3.1" reaches the
+// v1.3.1 build -- and reads the same as the version this plugin carries on the Plugin Portal.
 // Bump in step with SDK_VERSION in convention-publishing; the tag must exist before this resolves.
-private const val DEFAULT_SDK_VERSION = "1.3.0"
+private const val DEFAULT_SDK_VERSION = "1.3.1"
 
 /** JitPack's group for this repo — what auto-wiring declares. */
 private const val DEVCONSOLE_GROUP = "com.github.devconsole-android.DevConsole"

--- a/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
+++ b/gradle-plugin/src/test/kotlin/io/devconsole/gradle/DevConsoleVariantPolicyPluginFunctionalTest.kt
@@ -870,12 +870,12 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
         )
 
         // release is PROTECTED by default, so auto-wire adds the noop core coordinate. The published
-        // coordinate is 1.3.0 -- the DEFAULT_SDK_VERSION must not point at a 1.3.0-SNAPSHOT that was
+        // coordinate is 1.3.1 -- the DEFAULT_SDK_VERSION must not point at a 1.3.1-SNAPSHOT that was
         // never published, which would make every zero-config release build fail to resolve.
         val result = runner("dependencies", "--configuration", "releaseImplementation").build()
 
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.0"))
-        assertTrue(result.output, !result.output.contains("1.3.0-SNAPSHOT"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole-noop:1.3.1"))
+        assertTrue(result.output, !result.output.contains("1.3.1-SNAPSHOT"))
     }
 
     @Test
@@ -925,13 +925,13 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
     @Test
     fun `the JitPack coordinate trips the declared-dependency check`() {
-        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "1.3.0")
+        addStubCoordinate("com.github.devconsole-android.DevConsole", "devconsole", "1.3.1")
         writeFixture(
             devConsoleBlock = "autoWireDependencies.set(false)",
             extraBuildScript =
                 """
                 dependencies {
-                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:1.3.0")
+                    add("releaseImplementation", "com.github.devconsole-android.DevConsole:devconsole:1.3.1")
                 }
                 """.trimIndent(),
         )
@@ -971,7 +971,7 @@ class DevConsoleVariantPolicyPluginFunctionalTest {
 
         // debug is ENABLED, so the core runtime ("devconsole") must still be auto-wired alongside the
         // host's add-on declaration -- the add-on alone does not count as declaring the core runtime.
-        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.3.0"))
+        assertTrue(result.output, result.output.contains("com.github.devconsole-android.DevConsole:devconsole:1.3.1"))
         assertTrue(result.output, result.output.contains("io.github.devconsole-android:devconsole-ui-compose"))
     }
 

--- a/samples/compose-app/build.gradle.kts
+++ b/samples/compose-app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.compose"
         versionCode = 1
-        versionName = "1.3.0-SNAPSHOT"
+        versionName = "1.3.1-SNAPSHOT"
     }
 }
 

--- a/samples/foundation-app/build.gradle.kts
+++ b/samples/foundation-app/build.gradle.kts
@@ -31,6 +31,6 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample"
         versionCode = 1
-        versionName = "1.3.0-SNAPSHOT"
+        versionName = "1.3.1-SNAPSHOT"
     }
 }

--- a/samples/views-java-app/build.gradle.kts
+++ b/samples/views-java-app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId = "io.devconsole.sample.viewsjava"
         versionCode = 1
-        versionName = "1.3.0-SNAPSHOT"
+        versionName = "1.3.1-SNAPSHOT"
     }
 }
 

--- a/sdk/storage-room/README.md
+++ b/sdk/storage-room/README.md
@@ -9,7 +9,7 @@
 debugImplementation("com.github.devconsole-android.DevConsole:devconsole-storage-room:<version>")
 ```
 
-`<version>` is a JitPack version — `1.3.0` for the current release. Releases are tagged `v1.3.0`,
+`<version>` is a JitPack version — `1.3.1` for the current release. Releases are tagged `v1.3.1`,
 and JitPack resolves a bare version against the `v`-prefixed tag, so the `v` is optional; the bare
 form is used here because it also matches the plugin's version on the Gradle Plugin Portal.
 


### PR DESCRIPTION
Bumps SDK_VERSION, the Gradle plugin version, DEFAULT_SDK_VERSION, the sample versionNames, and every consumer-facing coordinate in the docs from 1.3.0 to 1.3.1.

A patch: the only change since the 1.3.0 tag is the per-variant protected-artifact verifier, which adds no public SDK API and breaks nothing -- the aggregate verifyDevConsoleProtectedArtifacts still exists for anyone naming it.

The CHANGELOG entries for that fix had been filed under 1.3.0, but they landed after the tag, so they move into their own 1.3.1 section.

## What

One or two sentences on what changed and why (the "why" matters more than the "what" — the diff
already shows the what).

## Verification

Which `./gradlew` commands did you run, and what did they confirm? (See
[CONTRIBUTING.md](../CONTRIBUTING.md#building-and-testing) for the standard set.)

- [ ] `./gradlew testDebugUnitTest` — passing
- [ ] `./gradlew ktlintCheck detekt` — clean (or new detekt findings are justified, not baselined away)
- [ ] `./gradlew apiCheck` — clean, or `apiDump` is included in this diff because the public API changed
- [ ] If this touches a debug/release or protected-variant boundary: sample assemble/verify commands
      run for the affected sample(s) (`:samples:<name>:assembleRelease
      :samples:<name>:verifyDevConsoleProtectedArtifacts`)

## Checklist

- [ ] Capture-path code (network/socket/push) never throws into the host app
- [ ] No new sensitive data is captured, logged, or exported without going through
      `RedactionEngine` first
- [ ] Docs updated if behavior, an API, or a config field changed
      (see [docs/README.md](../docs/README.md) for the index)
- [ ] This PR is scoped to one logical change

## Anything reviewers should look at closely

Optional — call out anything you're unsure about, a tradeoff you made, or a spot you want a second
look at.
