### PR TITLE
Feature/dashboard UI refactor

### DIFF
--- a/docs/DESIGN_SPEC.md
+++ b/docs/DESIGN_SPEC.md
@@ -239,20 +239,20 @@ Network, WebSockets, Push and Crashes. Timeline hand-rolls its own head from the
 is the odd one out; folding it into the helper is an open item (§9).
 
 ```
-┌ .detail-head ───────────────────────────────────────────────┐
-│ [BADGE] [MOCK] title (mono, ellipsis)      STATUS  [⤢] [⋮]  │  head row
-│ ‹facts strip — see below›                                   │  .detail-facts
-│ ‹actions row — see below›                                   │  .detail-actions-row
-│ Summary │ Request & response │ Headers │ …        [Stacked] │  .detail-tabs
-├ .detail-find (compare/diff tabs only) ──────────────────────┤
-│ 🔍 Find in headers, payload and response…   N matches       │
-├ .detail-body (scrolls) ─────────────────────────────────────┤
-│  ┌ .sbs-pane ─────────┐  ┌ .sbs-pane ─────────┐             │
-│  │ ● Request   [Copy] │  │ ● Response  [Copy] │             │  .sbs-grid
-│  │ › Request headers  │  │ › Response headers │             │  collapsed
-│  │ ⌄ Payload          │  │ ⌄ Body             │             │  expanded
-│  └────────────────────┘  └────────────────────┘             │
-│  🔒 redaction footnote                                       │
+┌ .detail-head ────────────────────────────────────────────────┐
+│ [BADGE] [MOCK] title (mono, ellipsis)    STATUS  [⤢] [⋮]     │  head row
+│ ‹facts strip — see table below›                              │  .detail-facts
+│ ‹actions row — see table below›                              │  .detail-actions-row
+│ Summary │ Request & response │ Headers │ …    [Stacked]      │  .detail-tabs
+├ .detail-find (compare/diff tabs only) ───────────────────────┤
+│ Find in headers, payload and response…      N matches        │
+├ .detail-body (scrolls) ──────────────────────────────────────┤
+│  ┌ .sbs-pane ────────┐  ┌ .sbs-pane ────────┐                │  .sbs-grid
+│  │ ● Request  [Copy] │  │ ● Response [Copy] │                │
+│  │ › Request headers │  │ › Response headers│                │  collapsed
+│  │ ⌄ Payload         │  │ ⌄ Body            │                │  expanded
+│  └───────────────────┘  └───────────────────┘                │
+│  redaction footnote                                          │
 └──────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/DESIGN_SPEC.md
+++ b/docs/DESIGN_SPEC.md
@@ -232,6 +232,63 @@ must recompute mid-scroll rather than assume) — see §9.
 - **Toolbar** (`.toolbar`): flex row, wraps, `align-items: flex-end` so label-stacked fields
   (uppercase label over input) share a bottom baseline with bare buttons. (This was a bug — see §9.)
 
+## 4a. Detail pane anatomy (split views)
+
+Four of the five split views build their right-hand pane from one shared helper (`detailHeadHtml`) —
+Network, WebSockets, Push and Crashes. Timeline hand-rolls its own head from the same classes and
+is the odd one out; folding it into the helper is an open item (§9).
+
+```
+┌ .detail-head ───────────────────────────────────────────────┐
+│ [BADGE] [MOCK] title (mono, ellipsis)      STATUS  [⤢] [⋮]  │  head row
+│ ‹facts strip — see below›                                   │  .detail-facts
+│ ‹actions row — see below›                                   │  .detail-actions-row
+│ Summary │ Request & response │ Headers │ …        [Stacked] │  .detail-tabs
+├ .detail-find (compare/diff tabs only) ──────────────────────┤
+│ 🔍 Find in headers, payload and response…   N matches       │
+├ .detail-body (scrolls) ─────────────────────────────────────┤
+│  ┌ .sbs-pane ─────────┐  ┌ .sbs-pane ─────────┐             │
+│  │ ● Request   [Copy] │  │ ● Response  [Copy] │             │  .sbs-grid
+│  │ › Request headers  │  │ › Response headers │             │  collapsed
+│  │ ⌄ Payload          │  │ ⌄ Body             │             │  expanded
+│  └────────────────────┘  └────────────────────┘             │
+│  🔒 redaction footnote                                       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Two variants of the head's middle band.** The facts strip and the actions row are per-pane
+choices, not fixed furniture:
+
+| Pane | Facts strip | Actions |
+|---|---|---|
+| **Network** | none — folded into the Summary tab | kebab **⋮** menu, right of the expand button |
+| WebSockets, Push, Crashes | `.detail-facts` row under the title | flat `.detail-actions-row` |
+
+The kebab is opt-in via `detailHeadHtml`'s `actionsMenu` flag. Network carries up to seven actions
+(flag, pin, resend, clone, mock *or* unmock, cURL, fetch) — a full row of buttons for controls
+used occasionally, not per-capture. The other panes carry two or three, where a row costs nothing
+and a menu would only add a click. Menu items keep the same `data-detail-action` ids as row
+buttons, so a pane's delegated click handler is identical either way. The panel is
+`position: fixed` (placed by `positionDetailMenuPanel()`) because `.detail-pane-v2` is
+`overflow: hidden` and an absolutely positioned popup clips at the pane edge — the same trade
+`.drop-panel` makes. It closes on pick, outside click, and Escape (returning focus to its button).
+
+**Network's tab order** is `Summary · Request & response · [Diff vs baseline] · Headers · Timing ·
+Related events`. Summary leads because it absorbed the head's old facts strip and is the "what is
+this capture" view: time, duration, request url/method, response status, `response.error` on a
+failure, content type, correlation id, mock rule (a link into Mocks), vs-original field count, and
+tags. Diff only appears once a baseline is pinned. **Default selection is Request & response**, not
+the first tab — the body is what an engineer opens a capture to read.
+
+Consequently Network's two compare panes hold only headers and body; they have no "General" group,
+because everything it used to duplicate now lives one tab left. Group collapse defaults come from
+`detailGroupHtml`: `Payload`/`Body` open, everything else collapsed, an explicit user toggle always
+winning over the default.
+
+**Simple mode** hides the Headers/Timing/Related tabs outright, and hides individual actions that
+carry `hideInSimple` (`fetch` always; `pin` only while no baseline is pinned, so a pinned baseline
+can never be stranded behind a mode switch).
+
 ## 4b. Layout (Android in-app inspector)
 
 - **Bottom nav, 4 destinations:** `01 Observe · 02 Control · 03 Data · 04 More` (numbered + label,
@@ -300,7 +357,9 @@ tray screen becomes a natural addition, just not one this pass builds.
 - **Segmented control** (`.seg`): joined buttons, one active (signal).
 - **Chips / chip-row** (`.chip-row`): wrapping pill filters.
 - **Cards** (`.card`): panel surface, 1px `--line`, 16px pad, `h2` with small leading icon.
-- **Split panes:** `.list` (rows) + `.splitter` + `.detail-pane` (min-width 300px).
+- **Split panes:** `.list-pane` (rows) + `.splitter` (5px) + `.detail-pane-v2`, inside `.split-shell`
+  (min 360px per column). Detail-pane anatomy — head, facts/actions variants, tabs, find bar,
+  side-by-side groups — is specified in §4a.
 - **Data table** (`.db-table`): real `<table>`, `<th scope=col>`, truncation via `.db-truncated`,
   horizontal scroll in `.db-table-wrap`.
 - **Empty states** (`.empty-state`): centered icon + title + sub. Used widely — design these well;
@@ -317,9 +376,10 @@ tray screen becomes a natural addition, just not one this pass builds.
 
 1. **Overview** — landing / status summary, connect prompt when unauthenticated, and the
    previous-run-crashed banner (see [CRASH_AND_ANR.md](CRASH_AND_ANR.md#the-previous-run-crashed-banner)).
-2. **Network** — captured HTTP list + detail; toolbar (search, status seg, method seg, Apply, Clear,
-   HAR, Postman); detail action row (Clone to composer, cURL, fetch, JSON, Related events); redacted
-   metadata pane.
+2. **Network** — captured HTTP list + detail; toolbar (search, status seg, method seg, service drop,
+   HAR, Postman, Clear) over a "More filters" disclosure; redacted metadata pane whose actions
+   (flag, pin, resend, clone, mock/unmock, cURL, fetch) live in the head's **⋮ menu** and whose tabs
+   lead with Summary — see §4a.
 3. **WebSockets** — socket sessions (URL, STATE/SENT/RECV), frame list per socket.
 4. **Timeline** — unified event timeline (search).
 5. **Crashes** — crash/ANR list + detail: kind/thread badges, breadcrumb strip, the all-thread dump
@@ -427,6 +487,10 @@ The final web visual contract relies on a rigid separation of concerns. `dashboa
   next step: the device's More screen, the `adb forward tcp:8080 tcp:8080` command (with its caveat
   that 8080 is only the first port tried), and the two browser access modes: a bare URL by default or
   the `#code=` credential when SESSION_CODE is selected.
+- **Network's detail head carried three stacked strips** (facts, actions, tabs) before the panes
+  even started, each duplicating something already on screen — the facts repeated the compare
+  panes' "General" groups. Facts moved into the Summary tab, the General groups went away, the
+  actions row became a ⋮ menu, and Summary was ordered first. See §4a.
 - **Cross-surface parity was undecided** — resolved and documented in §4c, with a full 16-row table
   of which web views the Android inspector mirrors, which it deliberately doesn't (Composer, capture
   rules, Overview), and one open naming mismatch (Timeline / Logs) left as a documented gap rather
@@ -435,6 +499,8 @@ The final web visual contract relies on a rigid separation of concerns. `dashboa
 **Open / worth a design eye:**
 - **Table/detail density** on Network/Database detail panes — readability at scale — is still
   unaddressed by this pass.
+- **Timeline's detail head is hand-rolled** rather than built from `detailHeadHtml` like the other
+  three split views (§4a), so it drifts from them silently whenever the shared helper changes.
 - **The Timeline / Logs naming mismatch** (§4c) — same underlying event stream, different name on
   each surface. Documented, not fixed; fixing it is a code change (renaming `ObserveTab.LOGS` or the
   web view, or both to a shared name), out of scope for a documentation-only pass.

--- a/sdk/server-ktor/src/main/resources/devconsole-web/dashboard.css
+++ b/sdk/server-ktor/src/main/resources/devconsole-web/dashboard.css
@@ -851,6 +851,30 @@ body.detail-zoom .split-shell.collapse-detail { grid-template-columns: 1fr; }
 .detail-head-status { font-family: var(--font-mono); font-size: 13px; font-weight: 700; }
 .detail-expand { display: grid; place-items: center; width: 26px; height: 26px; padding: 0; flex: 0 0 auto; border: 1px solid var(--line); border-radius: 8px; background: var(--surface-2); color: var(--muted); }
 .detail-expand.active { border-color: var(--signal); background: var(--signal-soft); color: var(--signal); }
+
+/* Kebab (⋮) actions menu, sitting immediately right of .detail-expand — same 26px footprint, so
+   the head row's right edge reads as one pair of controls rather than two sizes. */
+.detail-menu-btn { display: grid; place-items: center; width: 26px; height: 26px; padding: 0; flex: 0 0 auto; border: 1px solid var(--line); border-radius: 8px; background: var(--surface-2); color: var(--muted); }
+.detail-menu-btn:hover { color: var(--ink); border-color: var(--border-strong); }
+.detail-menu-btn.active { border-color: var(--signal); background: var(--signal-soft); color: var(--signal); }
+/* position: fixed, not absolute: .detail-pane-v2 is overflow: hidden, so an absolutely positioned
+   popup would be clipped at the pane's edge. Placed by positionDetailMenuPanel(), same contract
+   as the toolbar dropdowns' .drop-panel. */
+.detail-menu-panel {
+  position: fixed; z-index: 200; min-width: 200px; max-width: min(92vw, 320px);
+  display: grid; gap: 1px; padding: 4px;
+  background: var(--panel); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: var(--elev-3);
+}
+.detail-menu-item {
+  display: flex; align-items: center; gap: 8px; width: 100%; height: 30px; padding: 0 8px;
+  border: none; border-radius: 6px; background: transparent; text-align: left; color: var(--muted); font-size: 12.5px;
+}
+.detail-menu-item .ic { flex: 0 0 auto; color: var(--text-3); }
+.detail-menu-item:hover:not(:disabled) { background: var(--surface-2); color: var(--ink); }
+.detail-menu-item:hover:not(:disabled) .ic { color: inherit; }
+.detail-menu-item.on { color: var(--signal); background: var(--signal-soft); }
+.detail-menu-item.on .ic { color: var(--signal); }
+.detail-menu-item:disabled { opacity: 0.5; cursor: not-allowed; }
 .detail-facts { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 8px; }
 .detail-fact { display: flex; align-items: baseline; gap: 8px; font-size: 11.5px; }
 .detail-fact-k { font-size: 10.5px; font-weight: 600; color: var(--text-3); }
@@ -920,6 +944,10 @@ body.detail-zoom .split-shell.collapse-detail { grid-template-columns: 1fr; }
 /* Find-highlight must win over both grid sizes' background overrides above — same (0,3,0)
    specificity as `.kv-grid.kv-grid-lg .kv-v` but declared after it, so source order decides. */
 .kv-grid .kv-k.hit, .kv-grid .kv-v.hit { background: var(--signal-soft); }
+/* Clickable kv value (Network summary's "mock rule: <id>" → Mocks). A <button> inside .kv-v, so
+   it resets to the cell's own type instead of the UA button defaults. */
+.kv-link { font: inherit; color: var(--signal); background: transparent; border: none; padding: 0; border-radius: 4px; cursor: pointer; }
+.kv-link:hover { text-decoration: underline; }
 
 /* Code blocks with JSON syntax tokens */
 .code-block { border: 1px solid var(--line); border-radius: 6px; background: var(--code-bg); padding: 8px 12px; overflow-x: auto; }

--- a/sdk/server-ktor/src/main/resources/devconsole-web/dashboard.js
+++ b/sdk/server-ktor/src/main/resources/devconsole-web/dashboard.js
@@ -99,6 +99,9 @@
   let networkTab = 'compare';
   let networkDetailQuery = '';
   let networkSbsStacked = false;
+  // Open state of the detail pane's kebab (⋮) actions menu. Module-level, not DOM state, because
+  // renderNetworkDetail replaces the whole pane via innerHTML on every keystroke in the find box.
+  let networkActionsMenuOpen = false;
   // Backing state for the 'related' detail tab — see loadRelatedEvents/renderNetworkDetail.
   let networkRelatedEvents = [];
   let networkRelatedEventsForId = null;
@@ -712,10 +715,18 @@
     }));
     return n;
   }
+  /** `mockRuleLink: true` on a row renders its value as the same "open this rule in Mocks" button
+   * the detail head's facts row used to carry — the delegated `[data-open-mock-rule]` handler in
+   * wireNetworkDetailPane already covers anything inside the detail pane, head or body. */
   function kvGridHtml(rows, large) {
     if (!rows.length) return '';
     return `<div class="kv-grid${large ? ' kv-grid-lg' : ''}">${rows
-      .map((r) => `<span class="kv-k${r.hit ? ' hit' : ''}">${esc(r.k)}</span><span class="kv-v${r.tone ? ' tone-text-' + r.tone : ''}${r.hit ? ' hit' : ''}">${esc(r.v)}</span>`)
+      .map((r) => {
+        const v = r.mockRuleLink
+          ? `<button type="button" class="kv-link" data-open-mock-rule="${esc(r.v)}" title="Open ${esc(r.v)} in Mocks">${esc(r.v)}</button>`
+          : esc(r.v);
+        return `<span class="kv-k${r.hit ? ' hit' : ''}">${esc(r.k)}</span><span class="kv-v${r.tone ? ' tone-text-' + r.tone : ''}${r.hit ? ' hit' : ''}">${v}</span>`;
+      })
       .join('')}</div>`;
   }
   function barsHtml(bars) {
@@ -3686,6 +3697,10 @@
     const inside = (id) => path.some((el) => el.id === id);
     if (networkHostDropOpen && !inside('networkHostDrop')) { networkHostDropOpen = false; renderNetworkHostDrop(); }
     if (socketConnDropOpen && !inside('socketConnDrop')) { socketConnDropOpen = false; renderSocketConnDrop(); }
+    // The detail pane's kebab menu closes on the same rule. Its own button and items are handled
+    // in wireNetworkDetailPane (which runs first, on the pane), so by the time this fires they
+    // have already cleared the flag — this only catches genuine outside clicks.
+    if (networkActionsMenuOpen && !inside('detailActionsMenuPanel') && !inside('detailActionsMenuBtn')) { networkActionsMenuOpen = false; renderNetworkDetail(); }
   }
 
   function renderNetworkHostDrop() {
@@ -6578,8 +6593,15 @@
    * inside `.detail-head` instead, where `flex`/`min-height`/`overflow` mean nothing — so a body
    * taller than the pane grew the head past it and `.detail-pane-v2`'s `overflow: hidden` simply
    * cut it off, with nothing anywhere able to scroll to the rest. */
-  function detailHeadHtml({ badgeText, badgeTone, title, statusText, sTone, mocked, extraBadge, facts, actions, tabs, layoutToggle }) {
+  /** `actionsMenu` opts a pane out of the flat `.detail-actions-row` and into a kebab (⋮) menu
+   * beside the expand button — same `actions` model, same `data-detail-action` ids, so a pane's
+   * existing delegated click handler covers the items unchanged. Opt-in per pane (Network only
+   * today) rather than a blanket switch: the other detail panes carry two or three actions each,
+   * where a row costs nothing and a menu would only add a click. `menuOpen` is the caller's own
+   * state, since these panes re-render wholesale and the flag has to outlive the innerHTML swap. */
+  function detailHeadHtml({ badgeText, badgeTone, title, statusText, sTone, mocked, extraBadge, facts, actions, tabs, layoutToggle, actionsMenu, menuOpen }) {
     const zoom = document.body.classList.contains('detail-zoom');
+    const hasActions = actions && actions.length;
     return `<div class="detail-head">
       <div class="detail-head-row">
         <span class="detail-badge badge-${badgeTone}">${esc(badgeText)}</span>
@@ -6588,6 +6610,25 @@
         <span class="detail-head-title">${esc(title)}</span>
         <span class="detail-head-status tone-text-${sTone || 'muted'}">${esc(statusText || '')}</span>
         <button type="button" class="detail-expand${zoom ? ' active' : ''}" data-action="toggle-zoom" aria-pressed="${zoom}" title="${zoom ? 'Restore the split view (f)' : 'Expand this pane to full width (f)'}">${icon(zoom ? 'collapse' : 'expand', 'ic-sm')}</button>
+        ${
+          actionsMenu && hasActions
+            ? `<button type="button" class="detail-menu-btn${menuOpen ? ' active' : ''}" id="detailActionsMenuBtn" data-action="toggle-actions-menu" aria-haspopup="menu"${
+                menuOpen ? ' aria-controls="detailActionsMenuPanel"' : ''
+              } aria-expanded="${Boolean(menuOpen)}" title="Actions">${icon('dots', 'ic-sm')}</button>
+        ${
+          menuOpen
+            ? `<div class="detail-menu-panel" id="detailActionsMenuPanel" role="menu" aria-label="Actions">${actions
+                .map(
+                  (a) =>
+                    `<button type="button" role="menuitem" class="detail-menu-item${a.on ? ' on' : ''}${a.hideInSimple ? ' detail-action-hide-simple' : ''}" data-detail-action="${esc(
+                      a.id,
+                    )}" ${a.disabled ? 'disabled' : ''} title="${esc(a.title || a.label)}">${a.icon ? icon(a.icon, 'ic-sm') : ''}<span>${esc(a.label)}</span></button>`,
+                )
+                .join('')}</div>`
+            : ''
+        }`
+            : ''
+        }
       </div>
       ${
         facts && facts.length
@@ -6600,7 +6641,7 @@
               .join('')}</div>`
           : ''
       }
-      ${actions && actions.length ? `<div class="detail-actions-row">${actions.map((a) => `<button type="button" class="detail-action-btn${a.on ? ' on' : ''}${a.hideInSimple ? ' detail-action-hide-simple' : ''}" data-detail-action="${esc(a.id)}" ${a.disabled ? 'disabled' : ''} title="${esc(a.title || a.label)}">${a.icon ? icon(a.icon, 'ic-sm') : ''}${esc(a.label)}</button>`).join('')}</div>` : ''}
+      ${hasActions && !actionsMenu ? `<div class="detail-actions-row">${actions.map((a) => `<button type="button" class="detail-action-btn${a.on ? ' on' : ''}${a.hideInSimple ? ' detail-action-hide-simple' : ''}" data-detail-action="${esc(a.id)}" ${a.disabled ? 'disabled' : ''} title="${esc(a.title || a.label)}">${a.icon ? icon(a.icon, 'ic-sm') : ''}${esc(a.label)}</button>`).join('')}</div>` : ''}
       ${
         tabs && tabs.length
           ? `<div class="detail-tabs">${tabs.map((t) => `<button type="button" class="detail-tab${t.active ? ' active' : ''}" data-detail-tab="${esc(t.id)}">${esc(t.label)}${t.count ? `<span class="detail-tab-count">${esc(t.count)}</span>` : ''}</button>`).join('')}${
@@ -6778,8 +6819,9 @@
     const reqPane = {
       side: 'Request', dotTone: 'put', meta: detail.method + (detail.request?.contentType ? ' · ' + detail.request.contentType : ''), metaTone: 'muted',
       actions: [{ id: 'copy-request', label: 'Copy', icon: 'copy', title: 'Copy the whole request (line, headers, payload)' }],
+      // No 'General' group: url/method/sent-at are the Summary tab's job now (see
+      // networkSummaryKvs), and this tab is for the headers and the body.
       groups: [
-        { label: 'General', copyLabel: 'request line', kvs: markKvHits([{ k: 'url', v: detail.request?.url || '' }, { k: 'method', v: detail.method }, { k: 'sent at', v: time(detail.startedAtEpochMs) }], query) },
         { label: 'Request headers', copyLabel: 'request headers', meta: String(headerRows(detail.request?.headers).length), kvs: markKvHits(headerRows(detail.request?.headers), query) },
         reqBody
           ? { label: 'Payload', copyLabel: 'request payload', meta: detail.request?.contentType || '', code: reqBody, body: { raw: bodyRawText(detail.request?.body), contentType: detail.request?.contentType } }
@@ -6794,16 +6836,16 @@
       actions: hasResponse
         ? [{ id: 'copy-response', label: 'Copy', icon: 'copy', title: 'Copy the whole response (status, headers, body)' }]
         : [{ id: 'copy-error', label: 'Copy error', icon: 'copy' }],
+      // Same as the request pane: no 'General' group — status/duration/content type (and, on the
+      // failure branch, the error string) live in the Summary tab.
       groups: hasResponse
         ? [
-            { label: 'General', copyLabel: 'status line', kvs: markKvHits([{ k: 'status', v: String(detail.status) }, { k: 'duration', v: (detail.durationMs ?? '—') + ' ms' }, { k: 'content type', v: detail.response.contentType || '—' }], query) },
             { label: 'Response headers', copyLabel: 'response headers', meta: String(headerRows(detail.response.headers).length), kvs: markKvHits(headerRows(detail.response.headers), query) },
             resBody
               ? { label: 'Body', copyLabel: 'response body', meta: detail.response.contentType || '', code: resBody, body: { raw: bodyRawText(detail.response.body), contentType: detail.response.contentType, diffInfo, diffSig } }
               : { label: 'Body', empty: 'No body.' },
           ]
         : [
-            { label: 'General', copyLabel: 'failure detail', kvs: markKvHits([{ k: 'status', v: '— no response' }, { k: 'error', v: detail.error || 'unknown' }], query) },
             { label: 'Response headers', empty: 'Connection failed before headers arrived.' },
             { label: 'Body', empty: 'No body.' },
           ],
@@ -6858,14 +6900,26 @@
     };
   }
 
-  function networkSummaryKvs(detail) {
+  /** The detail head used to repeat time/duration/content type/correlation/mock rule as a facts
+   * strip under the title; they live here now (one place, one format) so the head stays title +
+   * actions + tabs. `mockRuleId`/`mockDiffTotal` are computed in renderNetworkDetail (they need
+   * mockRulesCache) and passed down rather than recomputed. */
+  function networkSummaryKvs(detail, { mockRuleId, mockDiffTotal } = {}) {
     const rows = [
+      { k: 'time', v: time(detail.startedAtEpochMs) },
+      { k: 'duration', v: detail.durationMs != null ? detail.durationMs + ' ms' : '—' },
       { k: 'request.url', v: detail.request?.url || '' },
       { k: 'request.method', v: detail.method },
-      { k: 'response.status', v: detail.status != null ? String(detail.status) : detail.error ? '— (' + detail.error + ')' : '—', tone: statusTone(detail.status) },
+      { k: 'response.status', v: detail.status != null ? String(detail.status) : detail.error ? '— no response' : '—', tone: statusTone(detail.status) },
     ];
+    // The error string used to be parenthesised into response.status above, and to double as the
+    // compare tab's failure "General" group. Both are gone: this is its one home, on its own row
+    // so a long exception message isn't buried inside another value.
+    if (detail.error) rows.push({ k: 'response.error', v: detail.error, tone: 'error' });
     if (detail.response?.contentType) rows.push({ k: 'response.contentType', v: detail.response.contentType });
     if (detail.correlationId) rows.push({ k: 'correlationId', v: detail.correlationId });
+    if (mockRuleId) rows.push({ k: 'mock rule', v: mockRuleId, mockRuleLink: true });
+    if (mockDiffTotal > 0) rows.push({ k: 'vs original', v: mockDiffTotal + (mockDiffTotal === 1 ? ' field differs' : ' fields differ') + ' from original', tone: 'warn' });
     const tags = Object.entries(detail.tags || {});
     if (tags.length) rows.push({ k: 'tags', v: tags.map(([k, v]) => k + '=' + v).join(', ') });
     return rows;
@@ -6917,10 +6971,12 @@
     if (networkTab === 'diff' && !pinId) networkTab = 'compare';
     const diffCount = hasPin ? diffHeaderStats(networkDetailCache.get(pinId), detail) : null;
     const relatedFresh = networkRelatedEventsForId === detail.id;
-    const tabs = [{ id: 'compare', label: 'Request & response' }]
+    // Summary leads: it absorbed the head's old facts strip (time/duration/content type/
+    // correlation/mock rule/error), so it is the "what is this capture" tab and reads first.
+    // `networkTab` still defaults to 'compare' — order here, not which tab opens selected.
+    const tabs = [{ id: 'summary', label: 'Summary' }, { id: 'compare', label: 'Request & response' }]
       .concat(pinId ? [{ id: 'diff', label: 'Diff vs baseline', count: hasPin ? String(diffCount.changed + diffCount.added) : 'pick one' }] : [])
       .concat([
-        { id: 'summary', label: 'Summary' },
         { id: 'headers', label: 'Headers', count: String(headerRows(detail.request?.headers).length + headerRows(detail.response?.headers).length) },
         { id: 'timing', label: 'Timing' },
         { id: 'related', label: 'Related events', count: relatedFresh ? String(networkRelatedEvents.length) : undefined },
@@ -6967,12 +7023,10 @@
       badgeText: detail.method, badgeTone: methodTone(detail.method), title: detail.host + detail.path,
       statusText: detail.status != null ? String(detail.status) : detail.error ? 'FAILED' : '—', sTone: statusTone(detail.status),
       mocked: isMocked,
-      facts: [{ k: 'time', v: time(detail.startedAtEpochMs) }, { k: 'duration', v: detail.durationMs != null ? detail.durationMs + ' ms' : '—' }]
-        .concat(detail.response?.contentType ? [{ k: 'content type', v: detail.response.contentType }] : [])
-        .concat(detail.correlationId ? [{ k: 'correlation', v: detail.correlationId }] : [])
-        .concat(mockRuleId ? [{ k: 'mock rule', v: mockRuleId, link: true }] : [])
-        .concat(mockDiffTotal > 0 ? [{ k: 'vs original', v: mockDiffTotal + (mockDiffTotal === 1 ? ' field differs' : ' fields differ') + ' from original' }] : []),
+      // No facts strip: time/duration/content type/correlation/mock rule now live in the Summary
+      // tab (see networkSummaryKvs) instead of being repeated under the title.
       actions, tabs, layoutToggle,
+      actionsMenu: true, menuOpen: networkActionsMenuOpen,
     });
     let findBar = '';
     let bodyHtml;
@@ -6994,7 +7048,7 @@
         bodyHtml = `<div class="sbs-grid${networkSbsStacked ? ' stacked' : ''}">${panes.map(sbsPaneHtml).join('')}</div>`;
       }
     } else if (networkTab === 'summary') {
-      bodyHtml = kvGridHtml(networkSummaryKvs(detail), true);
+      bodyHtml = kvGridHtml(networkSummaryKvs(detail, { mockRuleId, mockDiffTotal }), true);
     } else if (networkTab === 'headers') {
       bodyHtml = kvGridHtml(networkHeadersKvs(detail), true);
     } else if (networkTab === 'timing') {
@@ -7023,7 +7077,26 @@
     bodyHtml += `<div class="detail-footnote">${icon('lock', 'ic-sm')}<span>Headers and bodies are redacted by the on-device allowlist before they reach this browser. Values shown as •••• never left the app.</span></div>`;
     pane.innerHTML = head + findBar + `<div class="detail-body">${bodyHtml}</div>`;
     mountBodyViewers(pane);
+    // The menu panel is position: fixed (the detail pane is overflow: hidden, so an absolutely
+    // positioned popup would be clipped at the pane edge) — same trade the toolbar dropdowns make.
+    if (networkActionsMenuOpen) positionDetailMenuPanel();
     restoreFocus(focusSnap, pane);
+  }
+
+  /** Right-aligns the actions menu under its kebab button, flipping above when there isn't room
+   * below — the .drop-panel contract in positionDropPanel, minus the multi-select chrome. */
+  function positionDetailMenuPanel() {
+    requestAnimationFrame(() => {
+      const btn = $('detailActionsMenuBtn'), panel = $('detailActionsMenuPanel');
+      if (!btn || !panel) return;
+      const rc = btn.getBoundingClientRect();
+      const vh = window.innerHeight;
+      const below = vh - rc.bottom - 16;
+      const useBelow = below >= 200 || below >= rc.top - 16;
+      panel.style.left = Math.max(8, rc.right - panel.offsetWidth) + 'px';
+      if (useBelow) { panel.style.top = rc.bottom + 5 + 'px'; panel.style.bottom = 'auto'; }
+      else { panel.style.bottom = vh - rc.top + 5 + 'px'; panel.style.top = 'auto'; }
+    });
   }
 
   function detailActionText(id, detail) {
@@ -7048,6 +7121,7 @@
   function wireNetworkDetailPane() {
     const pane = $('networkDetailPane');
     pane.addEventListener('click', (e) => {
+      if (e.target.closest('[data-action="toggle-actions-menu"]')) { networkActionsMenuOpen = !networkActionsMenuOpen; renderNetworkDetail(); return; }
       if (e.target.closest('[data-action="toggle-zoom"]')) { toggleDetailZoom(); return; }
       const mockLink = e.target.closest('[data-open-mock-rule]');
       if (mockLink) { openMockRuleFromNetwork(mockLink.dataset.openMockRule); return; }
@@ -7082,6 +7156,11 @@
       const actionBtn = e.target.closest('[data-detail-action]');
       if (!actionBtn || !selectedTransactionDetail) return;
       const id = actionBtn.dataset.detailAction;
+      // Picking an item dismisses the menu, the way a menu is expected to behave — repainted here
+      // rather than per branch, because most branches (copy, cURL, clone-to-composer) don't
+      // re-render this pane themselves and would leave the popup hanging open over it. `id` is
+      // read first since the repaint detaches `actionBtn` from the tree.
+      if (networkActionsMenuOpen) { networkActionsMenuOpen = false; renderNetworkDetail(); }
       if (id === 'flag') { const d = selectedTransactionDetail; toggleEvidenceFlag('network', d.id, d.method + ' ' + d.host + d.path); renderNetworkDetail(); }
       else if (id === 'pin') pinNetworkBaseline(selectedTransactionId);
       else if (id === 'resend') resendCapturedRequest();
@@ -7814,6 +7893,7 @@
       // existing composedPath-based outside-click closer instead of replacing it.
       if (e.key === 'Escape' && networkHostDropOpen) { networkHostDropOpen = false; renderNetworkHostDrop(); $('networkHostDropBtn')?.focus(); return; }
       if (e.key === 'Escape' && socketConnDropOpen) { socketConnDropOpen = false; renderSocketConnDrop(); $('socketConnDropBtn')?.focus(); return; }
+      if (e.key === 'Escape' && networkActionsMenuOpen) { networkActionsMenuOpen = false; renderNetworkDetail(); $('detailActionsMenuBtn')?.focus(); return; }
       if (typing || dialogOpen || e.metaKey || e.ctrlKey || e.altKey) return;
       if (e.key === '/') { const id = viewFilterInput[currentView]; if (id && $(id)) { e.preventDefault(); $(id).focus(); } }
       else if (e.key === '?') { e.preventDefault(); toggleShortcuts(); }

--- a/sdk/server-ktor/src/main/resources/devconsole-web/index.html
+++ b/sdk/server-ktor/src/main/resources/devconsole-web/index.html
@@ -57,6 +57,7 @@ FINISH: unreviewed and undocumented is unfinished; this build ends with the fini
   <symbol id="dc-eye" viewBox="0 0 24 24"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></symbol>
   <symbol id="dc-expand" viewBox="0 0 24 24"><path d="M9 3H3v6M15 3h6v6M9 21H3v-6M15 21h6v-6"/></symbol>
   <symbol id="dc-collapse" viewBox="0 0 24 24"><path d="M3 9h6V3M21 9h-6V3M3 15h6v6M21 15h-6v6"/></symbol>
+  <symbol id="dc-dots" viewBox="0 0 24 24"><circle cx="12" cy="5" r="1.6" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="12" cy="19" r="1.6" fill="currentColor" stroke="none"/></symbol>
   <symbol id="dc-arrow-up" viewBox="0 0 24 24"><path d="M12 19V5M5 12l7-7 7 7"/></symbol>
   <symbol id="dc-arrow-down" viewBox="0 0 24 24"><path d="M12 5v14M5 12l7 7 7-7"/></symbol>
   <symbol id="dc-plug" viewBox="0 0 24 24"><path d="M9 2v6M15 2v6M7 8h10v3a5 5 0 0 1-10 0V8Z"/><path d="M12 16v6"/></symbol>


### PR DESCRIPTION
## What

Declutters the Network detail pane. Five changes:

- **Move the head's facts line into Summary** — time, duration, content type, correlation, mock rule 
- **Remove the "General" group from both the Request and Response panes** — Summary now holds
  everything it showed. Headers stay collapsed, payload/body expanded (already the default).
- **Give the error string a Summary row** (`response.error`) — General was its only home before,
  and General is gone.
- **Fold the action buttons into a ⋮ menu** at the top right, next to the expand button; click
  opens the list.
- **Put Summary first** in the tab order.

Web assets only (`dashboard.js`, `dashboard.css`, `index.html`); no Kotlin, no API surface, no
capture-path code.

## Verification

Which `./gradlew` commands did you run, and what did they confirm? (See
[CONTRIBUTING.md](../CONTRIBUTING.md#building-and-testing) for the standard set.)

- [x] `./gradlew :sdk:server-ktor:test` — passing (includes `DashboardAssetsTest`, the CSP guard
      that fails the build on inline scripts/handlers in these assets)
- [x] `./gradlew :sdk:server-ktor:ktlintCheck :sdk:server-ktor:detekt apiCheck` — clean
- [ ] `./gradlew ktlintCheck detekt` (repo-wide) — **fails on two pre-existing issues outside this
      diff**, both in files this PR does not touch (and which Kotlin lint could not be affected by,
      since this diff is `.js`/`.css`/`.html` only):
      - `samples/foundation-app/.../MainActivity.kt:335,504` — 4 ktlint violations
      - `sdk/server-api/.../LocalServerEngine.kt:205` — detekt `TooManyFunctions` on
        `SessionAuthority` (13/11)
- [x] `./gradlew apiCheck` — clean; no public API change, so no `apiDump` needed
- [ ] Debug/release boundary: not touched, no sample assemble/verify needed

## Checklist

- [x] Capture-path code (network/socket/push) never throws into the host app — not touched
- [x] No new sensitive data is captured, logged, or exported without going through
      `RedactionEngine` first — this only rearranges fields the pane already received and
      displayed; the redaction footnote is unchanged
- [x] Docs updated — `docs/DESIGN_SPEC.md` §4 describes the detail-pane layout and now trails the
     code on the facts strip and actions row. Happy to update it here or in a follow-up, reviewer's
      call.
- [x] This PR is scoped to one logical change

## Anything reviewers should look at closely

- **The kebab is opt-in, not global.** `detailHeadHtml` gained an `actionsMenu` flag that only
  `renderNetworkDetail` passes; WebSockets/Push/Crashes carry two or three actions each and keep
  their flat rows, where a menu would only add a click. One line each to flip them if you'd rather
  the chrome be uniform.
- **`.detail-menu-panel` is `position: fixed`,** placed by `positionDetailMenuPanel()`. It has to
  be — `.detail-pane-v2` is `overflow: hidden`, so an absolutely positioned popup clips at the pane
  edge. Same trade the toolbar `.drop-panel` dropdowns already make.
- **Menu items keep their `data-detail-action` ids,** so the existing delegated click handler in
  `wireNetworkDetailPane` covers them unchanged; only the markup moved.
- **Pre-existing, untouched, noticed in passing:** `copyNetworkCurl` and `cloneCapturedRequest`
  both do `if (!r.ok) return;` with no toast, so a failing `/curl` fetch is completely silent to
  the user. Out of scope here — worth its own fix.
